### PR TITLE
Allow loading core modules from a URL.

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/CommonJSRequireTest.java
+++ b/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/CommonJSRequireTest.java
@@ -680,6 +680,15 @@ public class CommonJSRequireTest {
     }
 
     @Test
+    public void importBuiltinModuleEsURL() throws IOException {
+        final String src = "import assert from 'assert'; assert.equal(42, 42); console.log('OK!');";
+        Map<String, String> options = getDefaultOptions();
+        Path path = getTestRootFolder().resolve("builtin-assert-mockup.mjs");
+        options.put(COMMONJS_CORE_MODULES_REPLACEMENTS_NAME, "assert:" + path.toUri().toString());
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "OK!\n", options);
+    }
+
+    @Test
     public void importNestedBuiltinModuleEs() throws IOException {
         Path root = getTestRootFolder();
         Path dirFile = Paths.get(root.toAbsolutePath().toString(), "nested_imports.js");

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/NpmCompatibleESModuleLoader.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/NpmCompatibleESModuleLoader.java
@@ -103,7 +103,7 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
     public JSModuleRecord resolveImportedModule(ScriptOrModule referencingModule, String specifier) {
         log("IMPORT resolve ", specifier);
         if (isCoreModule(specifier)) {
-            return loadCoreModule(specifier);
+            return loadCoreModule(referencingModule, specifier);
         }
         try {
             TruffleFile file = resolveURL(referencingModule, specifier);
@@ -114,7 +114,7 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
         }
     }
 
-    private JSModuleRecord loadCoreModule(String specifier) {
+    private JSModuleRecord loadCoreModule(ScriptOrModule referencingModule, String specifier) {
         log("IMPORT resolve built-in ", specifier);
         JSModuleRecord existingModule = moduleMap.get(specifier);
         if (existingModule != null) {
@@ -123,7 +123,15 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
         }
         String moduleReplacementName = realm.getContext().getContextOptions().getCommonJSRequireBuiltins().get(specifier);
         Source src;
-        if (moduleReplacementName != null && moduleReplacementName.endsWith(MODULE_SOURCE_NAME_SUFFIX)) {
+        URI maybeUri = asURI(moduleReplacementName);
+        if (maybeUri != null && moduleReplacementName != null && moduleReplacementName.endsWith(MODULE_SOURCE_NAME_SUFFIX)) {
+            TruffleFile file = resolveURL(referencingModule, moduleReplacementName);
+            try {
+                return loadModuleFromUrl(specifier, file, file.getPath());
+            } catch (IOException e) {
+                throw fail("Failed to load built-in ES module: " + specifier + ". " + e.getMessage());
+            }
+        } else if (moduleReplacementName != null && moduleReplacementName.endsWith(MODULE_SOURCE_NAME_SUFFIX)) {
             // Just load the module
             try {
                 String cwdOption = realm.getContext().getContextOptions().getRequireCwd();

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
@@ -295,7 +295,7 @@ public final class JSContextOptions {
                             }
                             String[] options = value.split(",");
                             for (String s : options) {
-                                String[] builtin = s.split(":");
+                                String[] builtin = s.split(":", 2);
                                 if (builtin.length != 2) {
                                     throw new IllegalArgumentException("Unexpected builtin arguments: " + s);
                                 }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/objects/DefaultESModuleLoader.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/objects/DefaultESModuleLoader.java
@@ -69,6 +69,8 @@ public class DefaultESModuleLoader implements JSModuleLoader {
     }
 
     protected URI asURI(String specifier) {
+        if (specifier == null)
+            return null;
         if (specifier.indexOf(':') == -1) {
             return null;
         }


### PR DESCRIPTION
This currently works for `.mjs` modules, not sure how to make it work for `.js` modules however.