### PR TITLE
Unhandled promise rejection handler

### DIFF
--- a/docs/user/JavaScriptCompatibility.md
+++ b/docs/user/JavaScriptCompatibility.md
@@ -219,11 +219,11 @@ The Graal object is available in GraalVM JavaScript by default, unless deactivat
 - If `true`, hot code is compiled by the GraalVM compiler, resulting in high peak performance.
 - If `false`, GraalVM JavaScript will not be optimized by the GraalVM Compiler, typically resulting in lower performance.
 
-### `Graal.registerPromiseRejectionHandler(handler)`
+### `Graal.setUnhandledPromiseRejectionHandler(handler)`
 
 - provides the unhandled promise rejection handler when using option (`js.unhandled-rejections=handler`).
 - the handler is called with two arguments: (rejection, promise).
-- `Graal.registerPromiseRejectionHandler` can be called with null, undefined, or empty args to clear the handler.
+- `Graal.setUnhandledPromiseRejectionHandler` can be called with null, undefined, or empty args to clear the handler.
 
 ### Java
 

--- a/docs/user/JavaScriptCompatibility.md
+++ b/docs/user/JavaScriptCompatibility.md
@@ -219,6 +219,12 @@ The Graal object is available in GraalVM JavaScript by default, unless deactivat
 - If `true`, hot code is compiled by the GraalVM compiler, resulting in high peak performance.
 - If `false`, GraalVM JavaScript will not be optimized by the GraalVM Compiler, typically resulting in lower performance.
 
+### `Graal.registerPromiseRejectionHandler(handler)`
+
+- provides the unhandled promise rejection handler when using option (`js.unhandled-rejections=handler`).
+- the handler is called with two arguments: (rejection, promise).
+- `Graal.registerPromiseRejectionHandler` can be called with null, undefined, or empty args to clear the handler.
+
 ### Java
 
 The `Java` object is only available when the engine is started in JVM mode (`--jvm` flag).

--- a/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/PromiseRejectionHandler.java
+++ b/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/PromiseRejectionHandler.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oracle.truffle.js.test.builtins;
+
+import com.oracle.truffle.js.test.JSTest;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class PromiseRejectionHandler {
+
+    @Test
+    public void testExists() {
+        try (Context context = newUnhandledRejectionContext()) {
+            assertTrue(registerHandlerFunctionExists(context));
+        }
+        try (Context context = JSTest.newContextBuilder().build()) {
+            assertFalse(registerHandlerFunctionExists(context));
+        }
+    }
+
+    @Test
+    public void testInvokeRegister() {
+        try (Context context = newUnhandledRejectionContext()) {
+            context.eval("js", "Graal.registerPromiseRejectionHandler(() => {}); Promise.reject('test')");
+            context.eval("js", "Graal.registerPromiseRejectionHandler(); Promise.reject('test')");
+            context.eval("js", "Graal.registerPromiseRejectionHandler(null); Promise.reject('test')");
+            context.eval("js", "Graal.registerPromiseRejectionHandler(undefined); Promise.reject('test')");
+        }
+    }
+
+    @Test
+    public void testSingleUnhandledRejection() {
+        try (Context context = newUnhandledRejectionContext()) {
+            context.eval("js", "count = 0; Graal.registerPromiseRejectionHandler(() => count++); Promise.reject('test')");
+            Value count = context.eval("js", "count");
+            assertEquals(1, count.asInt());
+        }
+    }
+
+    @Test
+    public void testUnhandledRejectionInHandler() {
+        try (Context context = newUnhandledRejectionContext()) {
+            context.eval("js", "" +
+                    "count = 0; " +
+                    "Graal.registerPromiseRejectionHandler(() => {" +
+                    "   if (count == 0) Promise.reject('testInner');" +
+                    "   count++;" +
+                    "}); " +
+                    "Promise.reject('test1')");
+            context.eval("js", "Promise.reject('test2')");
+            Value count = context.eval("js", "count");
+            assertEquals(3, count.asInt());
+        }
+    }
+
+    @Test
+    public void testFireArguments() {
+        try (Context context = newUnhandledRejectionContext()) {
+            final AtomicBoolean executed = new AtomicBoolean(false);
+            BiConsumer<Object, Object> testHandler = (rejection, promise) -> {
+                assertEquals("test", rejection);
+                assertNotNull(promise);
+                assertEquals("Promise", context.asValue(promise).getMetaObject().getMetaSimpleName());
+                executed.set(true);
+            };
+            context.getBindings("js").putMember("handler", testHandler);
+            context.eval("js", "Graal.registerPromiseRejectionHandler((r, p) => handler(r, p)); Promise.reject('test')");
+            assertTrue(executed.get());
+        }
+    }
+
+    @Test
+    public void testFireHostFunction() {
+        try (Context context = newUnhandledRejectionContext()) {
+            final AtomicBoolean executed = new AtomicBoolean(false);
+            BiConsumer<Object, Object> testHandler = (rejection, promise) -> {
+                executed.set(true);
+            };
+            context.getBindings("js").putMember("handler", testHandler);
+            context.eval("js", "Graal.registerPromiseRejectionHandler(handler); Promise.reject('test')");
+            assertTrue(executed.get());
+        }
+    }
+
+
+    Context newUnhandledRejectionContext() {
+        return JSTest.newContextBuilder().option("js.unhandled-rejections", "handler").allowAllAccess(true).build();
+    }
+
+    boolean registerHandlerFunctionExists(Context context) {
+        return context.eval("js", "'registerPromiseRejectionHandler' in Graal").asBoolean();
+    }
+}

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContext.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContext.java
@@ -334,7 +334,7 @@ public class JSContext {
         SegmenterPosition,
         FunctionAsyncIterator,
         IsGraalRuntime,
-        RegisterPromiseRejectionHandler,
+        SetUhandledPromiseRejectionHandler,
         AsyncModuleExecutionFulfilled,
         AsyncModuleExecutionRejected,
         TopLevelAwaitResolve,

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContext.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContext.java
@@ -334,6 +334,7 @@ public class JSContext {
         SegmenterPosition,
         FunctionAsyncIterator,
         IsGraalRuntime,
+        RegisterPromiseRejectionHandler,
         AsyncModuleExecutionFulfilled,
         AsyncModuleExecutionRejected,
         TopLevelAwaitResolve,

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
@@ -545,7 +545,7 @@ public final class JSContextOptions {
                     "Configure unhandled promise rejections tracking. Accepted values: 'none', unhandled rejections are not tracked. " +
                     "'warn', a warning is printed to stderr when an unhandled rejection is detected. " +
                     "'throw', an exception is thrown when an unhandled rejection is detected. " +
-                    "'handler', the handler function registered with Graal.registerPromiseRejectionHandler will be " +
+                    "'handler', the handler function set with Graal.setUnhandledPromiseRejectionHandler will be " +
                     "called with the rejection value and promise respectively as arguments.")
     public static final OptionKey<UnhandledRejectionsTrackingMode> UNHANDLED_REJECTIONS = new OptionKey<>(UnhandledRejectionsTrackingMode.NONE);
     @CompilationFinal private UnhandledRejectionsTrackingMode unhandledRejectionsMode;

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
@@ -530,7 +530,8 @@ public final class JSContextOptions {
     public enum UnhandledRejectionsTrackingMode {
         NONE,
         WARN,
-        THROW;
+        THROW,
+        HANDLER;
 
         @Override
         public String toString() {
@@ -539,10 +540,13 @@ public final class JSContextOptions {
     }
 
     public static final String UNHANDLED_REJECTIONS_NAME = JS_OPTION_PREFIX + "unhandled-rejections";
+
     @Option(name = UNHANDLED_REJECTIONS_NAME, category = OptionCategory.USER, help = "" +
                     "Configure unhandled promise rejections tracking. Accepted values: 'none', unhandled rejections are not tracked. " +
                     "'warn', a warning is printed to stderr when an unhandled rejection is detected. " +
-                    "'throw', an exception is thrown when an unhandled rejection is detected.") //
+                    "'throw', an exception is thrown when an unhandled rejection is detected. " +
+                    "'handler', the handler function registered with Graal.registerPromiseRejectionHandler will be " +
+                    "called with the rejection value and promise respectively as arguments.")
     public static final OptionKey<UnhandledRejectionsTrackingMode> UNHANDLED_REJECTIONS = new OptionKey<>(UnhandledRejectionsTrackingMode.NONE);
     @CompilationFinal private UnhandledRejectionsTrackingMode unhandledRejectionsMode;
 

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSRealm.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSRealm.java
@@ -1994,13 +1994,13 @@ public class JSRealm {
         JSObjectUtil.putDataProperty(context, graalObject, Strings.VERSION_ECMA_SCRIPT, esVersion, flags);
         JSObjectUtil.putDataProperty(context, graalObject, Strings.IS_GRAAL_RUNTIME, JSFunction.create(this, isGraalRuntimeFunction(context)), flags);
         if (options.getUnhandledRejectionsMode() == JSContextOptions.UnhandledRejectionsTrackingMode.HANDLER) {
-            JSFunctionObject registerFunction = JSFunction.create(this, setUnhandledPromiseRejectionHandlerFunction());
+            JSFunctionObject registerFunction = JSFunction.create(this, setUnhandledPromiseRejectionHandlerFunction(context));
             JSObjectUtil.putDataProperty(context, graalObject, Strings.SET_UNHANDLED_PROMISE_REJECTION_HANDLER, registerFunction, flags);
         }
         putGlobalProperty(Strings.GRAAL, graalObject);
     }
 
-    private JSFunctionData setUnhandledPromiseRejectionHandlerFunction() {
+    private static JSFunctionData setUnhandledPromiseRejectionHandlerFunction(JSContext context) {
         return context.getOrCreateBuiltinFunctionData(BuiltinFunctionKey.SetUhandledPromiseRejectionHandler, (c) -> {
             return JSFunctionData.createCallOnly(c, new JavaScriptRootNode(c.getLanguage(), null, null) {
                 @Override
@@ -2023,7 +2023,7 @@ public class JSRealm {
 
                 @TruffleBoundary
                 private void registerHandler(Object handlerFunctionObject) {
-                    unhandledPromiseRejectionHandler = handlerFunctionObject;
+                    JSRealm.get(null).unhandledPromiseRejectionHandler = handlerFunctionObject;
                 }
             }.getCallTarget(), 0, Strings.SET_UNHANDLED_PROMISE_REJECTION_HANDLER);
         });

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/Strings.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/Strings.java
@@ -460,7 +460,7 @@ public final class Strings {
     public static final TruffleString VERSION_GRAAL_VM = constant("versionGraalVM");
     public static final TruffleString VERSION_ECMA_SCRIPT = constant("versionECMAScript");
     public static final TruffleString IS_GRAAL_RUNTIME = constant("isGraalRuntime");
-    public static final TruffleString REGISTER_PROMISE_REJECTION_HANDLER = constant("registerPromiseRejectionHandler");
+    public static final TruffleString SET_UNHANDLED_PROMISE_REJECTION_HANDLER = constant("setUnhandledPromiseRejectionHandler");
     public static final TruffleString UC_PACKAGES = constant("Packages");
     public static final TruffleString JAVA = constant("java");
     public static final TruffleString JAVAFX = constant("javafx");

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/Strings.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/Strings.java
@@ -460,6 +460,7 @@ public final class Strings {
     public static final TruffleString VERSION_GRAAL_VM = constant("versionGraalVM");
     public static final TruffleString VERSION_ECMA_SCRIPT = constant("versionECMAScript");
     public static final TruffleString IS_GRAAL_RUNTIME = constant("isGraalRuntime");
+    public static final TruffleString REGISTER_PROMISE_REJECTION_HANDLER = constant("registerPromiseRejectionHandler");
     public static final TruffleString UC_PACKAGES = constant("Packages");
     public static final TruffleString JAVA = constant("java");
     public static final TruffleString JAVAFX = constant("javafx");


### PR DESCRIPTION
This PR includes a change that extends the graaljs-js unhandled promise exception handling to allow the option of handling unhandled promise rejections with a registered handler. This allows polyglot or `js` CLI applications to supply their own handling that can be used for custom logging or other behavior. Neither of the 3 existing options allowed me any kind of programmatic handling, and this change unlocked my use case and hopefully should for others.

Allow the handling of unhandled promise rejections by setting a handler in JS with
Graal.registerPromiseRejectionHandler() when the option `js.unhandled-rejections=handler`
is enabled.

- [x]  Manual testing (it works for my usecase).
- [x]  Unit tests