### PR TITLE
Implementation of Proposal tc39/proposal-change-array-by-copy

### DIFF
--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/ArrayPrototypeBuiltins.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/ArrayPrototypeBuiltins.java
@@ -113,6 +113,7 @@ import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArraySplic
 import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayToLocaleStringNodeGen;
 import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayToReversedNodeGen;
 import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayToSortedNodeGen;
+import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayToSplicedNodeGen;
 import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayToStringNodeGen;
 import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayUnshiftNodeGen;
 import com.oracle.truffle.js.builtins.helper.JSCollectionsNormalizeNode;
@@ -263,7 +264,8 @@ public final class ArrayPrototypeBuiltins extends JSBuiltinsContainer.SwitchEnum
 
         // https://github.com/tc39/proposal-change-array-by-copy
         toReversed(0),
-        toSorted(1);
+        toSorted(1),
+        toSpliced(2);
 
         private final int length;
 
@@ -377,6 +379,8 @@ public final class ArrayPrototypeBuiltins extends JSBuiltinsContainer.SwitchEnum
                 return JSArrayToReversedNodeGen.create(context, builtin, args().withThis().createArgumentNodes(context));
             case toSorted:
                 return JSArrayToSortedNodeGen.create(context, builtin, false, args().withThis().fixedArgs(1).createArgumentNodes(context));
+            case toSpliced:
+                return JSArrayToSplicedNodeGen.create(context, builtin, args().withThis().varArgs().createArgumentNodes(context));
         }
         return null;
     }
@@ -3756,6 +3760,106 @@ public final class ArrayPrototypeBuiltins extends JSBuiltinsContainer.SwitchEnum
                 array[index] = JSInteropUtil.readArrayElementOrDefault(thisObj, index, Undefined.instance, interop, importValue, this);
             }
             return array;
+        }
+    }
+
+    // TODO Schlaegl: Optimizations possible
+    public abstract static class JSArrayToSplicedNode extends JSArrayOperationWithToInt {
+
+        private final BranchProfile objectBranch = BranchProfile.create();
+        private final ConditionProfile argsLength0Profile = ConditionProfile.createBinaryProfile();
+        private final ConditionProfile argsLength1Profile = ConditionProfile.createBinaryProfile();
+        private final ConditionProfile offsetProfile = ConditionProfile.createBinaryProfile();
+        @Child private InteropLibrary arrayInterop;
+
+        public JSArrayToSplicedNode(JSContext context, JSBuiltin builtin) {
+            super(context, builtin);
+        }
+
+        @Specialization
+        protected JSDynamicObject toSpliced(Object thisArg, Object[] args) {
+            Object thisObj = toObject(thisArg);
+            long len = getLength(thisObj);
+            long actualStart = JSRuntime.getOffset(toIntegerAsLong(JSRuntime.getArgOrUndefined(args, 0)), len, offsetProfile);
+
+            long insertCount;
+            long actualDeleteCount;
+            if (argsLength0Profile.profile(args.length == 0)) {
+                insertCount = 0;
+                actualDeleteCount = 0;
+            } else if (argsLength1Profile.profile(args.length == 1)) {
+                insertCount = 0;
+                actualDeleteCount = len - actualStart;
+            } else {
+                assert args.length >= 2;
+                insertCount = args.length - 2;
+                long deleteCount = toIntegerAsLong(JSRuntime.getArgOrUndefined(args, 1));
+                actualDeleteCount = Math.min(Math.max(deleteCount, 0), len - actualStart);
+            }
+
+            long newLen = len + insertCount - actualDeleteCount;
+            if (newLen > JSRuntime.MAX_SAFE_INTEGER_LONG) {
+                errorBranch.enter();
+                throwLengthError();
+            }
+
+            JSDynamicObject resObj = (JSDynamicObject) getArraySpeciesConstructorNode().arrayCreate(newLen);
+
+            if (JSDynamicObject.isJSDynamicObject(thisObj)) {
+                objectBranch.enter();
+                spliceJSObject(resObj, thisObj, len, actualStart, actualDeleteCount, args);
+            } else {
+                spliceForeignArray(resObj, thisObj, len, actualStart, actualDeleteCount, args);
+            }
+
+            reportLoopCount(len);
+            return resObj;
+        }
+
+        private static long spliceInsert(JSDynamicObject dstObj, long toIndex, Object[] args) {
+            final int itemOffset = 2;
+            long dstIdx = toIndex;
+            for (int argIdx = itemOffset; argIdx < args.length; argIdx++) {
+                JSRuntime.createDataPropertyOrThrow(dstObj, Strings.fromLong(dstIdx++), args[argIdx]);
+            }
+            return dstIdx;
+        }
+
+        private void spliceJSObject(JSDynamicObject dstObj, Object srcObj, long len, long actualStart, long actualDeleteCount, Object[] args) {
+            long dstIdx = 0;
+            for (long srcIdx = 0; srcIdx < actualStart; srcIdx++) {
+                JSRuntime.createDataPropertyOrThrow(dstObj, Strings.fromLong(dstIdx++), read(srcObj, srcIdx));
+            }
+            dstIdx = spliceInsert(dstObj, dstIdx, args);
+            for (long srcIdx = actualStart + actualDeleteCount; srcIdx < len; srcIdx++) {
+                JSRuntime.createDataPropertyOrThrow(dstObj, Strings.fromLong(dstIdx++), read(srcObj, srcIdx));
+            }
+        }
+
+        private void spliceForeignArray(JSDynamicObject dstObj, Object srcObj, long len, long actualStart, long actualDeleteCount, Object args[]) {
+            InteropLibrary arrays = arrayInterop;
+            if (arrays == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                this.arrayInterop = arrays = insert(InteropLibrary.getFactory().createDispatched(JSConfig.InteropLibraryLimit));
+            }
+            try {
+                long dstIdx = 0;
+                for (long srcIdx = 0; srcIdx < actualStart; srcIdx++) {
+                    spliceForeignMoveValue(dstObj, srcObj, srcIdx, dstIdx++, arrays);
+                }
+                dstIdx = spliceInsert(dstObj, dstIdx, args);
+                for (long srcIdx = actualStart + actualDeleteCount; srcIdx < len; srcIdx++) {
+                    spliceForeignMoveValue(dstObj, srcObj, srcIdx, dstIdx++, arrays);
+                }
+            } catch (UnsupportedMessageException | InvalidArrayIndexException | UnsupportedTypeException e) {
+                throw Errors.createTypeErrorInteropException(srcObj, e, "splice", this);
+            }
+        }
+
+        private static void spliceForeignMoveValue(JSDynamicObject destObj, Object srcObj, long fromIndex, long toIndex, InteropLibrary arrays)
+                        throws UnsupportedMessageException, InvalidArrayIndexException, UnsupportedTypeException {
+            Object val = arrays.readArrayElement(srcObj, fromIndex);
+            arrays.writeArrayElement(destObj, toIndex, val);
         }
     }
 }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/TypedArrayPrototypeBuiltins.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/TypedArrayPrototypeBuiltins.java
@@ -78,6 +78,9 @@ import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArraySlice
 import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArraySomeNodeGen;
 import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArraySortNodeGen;
 import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayToLocaleStringNodeGen;
+import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayToReversedNodeGen;
+import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayToSortedNodeGen;
+import com.oracle.truffle.js.builtins.ArrayPrototypeBuiltinsFactory.JSArrayWithNodeGen;
 import com.oracle.truffle.js.builtins.TypedArrayPrototypeBuiltinsFactory.JSArrayBufferViewFillNodeGen;
 import com.oracle.truffle.js.builtins.TypedArrayPrototypeBuiltinsFactory.JSArrayBufferViewForEachNodeGen;
 import com.oracle.truffle.js.builtins.TypedArrayPrototypeBuiltinsFactory.JSArrayBufferViewIteratorNodeGen;
@@ -158,7 +161,12 @@ public final class TypedArrayPrototypeBuiltins extends JSBuiltinsContainer.Switc
 
         // ES 2023
         findLast(1),
-        findLastIndex(1);
+        findLastIndex(1),
+
+        // https://github.com/tc39/proposal-change-array-by-copy
+        toReversed(0),
+        toSorted(1),
+        with(2);
 
         private final int length;
 
@@ -243,6 +251,15 @@ public final class TypedArrayPrototypeBuiltins extends JSBuiltinsContainer.Switc
                 return JSArrayIncludesNodeGen.create(context, builtin, true, args().withThis().fixedArgs(2).createArgumentNodes(context));
             case at:
                 return JSArrayAtNodeGen.create(context, builtin, true, args().withThis().fixedArgs(1).createArgumentNodes(context));
+
+            // TODO Schlaegl: additional work needed to meet the spec
+            // (https://github.com/tc39/proposal-change-array-by-copy)
+            case toReversed:
+                return JSArrayToReversedNodeGen.create(context, builtin, args().withThis().createArgumentNodes(context));
+            case toSorted:
+                return JSArrayToSortedNodeGen.create(context, builtin, true, args().withThis().fixedArgs(1).createArgumentNodes(context));
+            case with:
+                return JSArrayWithNodeGen.create(context, builtin, args().withThis().fixedArgs(2).createArgumentNodes(context));
         }
         return null;
     }


### PR DESCRIPTION
Experimental implementation of [tc39/proposal-change-array-by-copy: Provides additional methods on Array.prototype and TypedArray.prototype to enable changes on the array by returning a new copy of it with the change.](https://github.com/tc39/proposal-change-array-by-copy)

**Implemented:**
- `Array.prototype.toReversed() -> Array`
- `Array.prototype.toSorted(compareFn) -> Array` .. TODO: Generalization necessary: see specification: *sort*, *SortIndexedProperties*, *CompareArrayElements*, ...)
- `Array.prototype.toSpliced(start, deleteCount, ...items) -> Array` ..  TODO: Optimizations possible.
- `Array.prototype.with(index, value) -> Array`
- `TypedArray.prototype.toReversed() -> TypedArray` .. TODO: Additional work is required to meet the specification.
- `TypedArray.prototype.toSorted(compareFn) -> TypedArray` .. TODO: Additional work is required to meet the specification.
- `TypedArray.prototype.with(index, value) -> TypedArray` .. TODO: Additional work is required to meet the specification.
