### PR TITLE
Implements `toReversed` and `toSorted` array builtins

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/ArrayPrototypeBuiltins.java
+++ b/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/ArrayPrototypeBuiltins.java
@@ -42,7 +42,6 @@ package com.oracle.truffle.js.test.builtins;
 
 import com.oracle.truffle.js.lang.JavaScriptLanguage;
 import com.oracle.truffle.js.runtime.JSContextOptions;
-import com.oracle.truffle.js.runtime.JSException;
 import com.oracle.truffle.js.test.JSTest;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
@@ -159,8 +158,8 @@ public class ArrayPrototypeBuiltins {
 
             testArray(src, expected.length, expected);
 
-            src = "['abcd', 'hello', 't2xs', 'fge^°'].toReversed();";
-            expected = new String[]{"fge^°", "t2xs", "hello", "abcd"};
+            src = "['abcd', 'hello', 't2xs', 'fge^?'].toReversed();";
+            expected = new String[]{"fge^?", "t2xs", "hello", "abcd"};
 
             testArray(src, expected.length, expected);
         }
@@ -199,7 +198,7 @@ public class ArrayPrototypeBuiltins {
         public void throwsTypeErrorIfCompareFunctionIsInvalid() {
             String src = "[41, 42, 43, 44, 45].toSorted(32);";
             try {
-                executeSourceForResult(src, value -> {});
+                executeSourceForResult(src, value -> { });
                 fail("expected TypeError to be thrown");
             } catch (PolyglotException e) {
                 assertEquals("TypeError: The comparison function must be either a function or undefined", e.getMessage());

--- a/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/ArrayPrototypeBuiltins.java
+++ b/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/ArrayPrototypeBuiltins.java
@@ -40,18 +40,17 @@
  */
 package com.oracle.truffle.js.test.builtins;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import com.oracle.truffle.js.lang.JavaScriptLanguage;
 import com.oracle.truffle.js.runtime.JSContextOptions;
+import com.oracle.truffle.js.test.JSTest;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.oracle.truffle.js.lang.JavaScriptLanguage;
-import com.oracle.truffle.js.test.JSTest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ArrayPrototypeBuiltins {
 
@@ -133,5 +132,56 @@ public class ArrayPrototypeBuiltins {
             Assert.assertEquals(44, evenResult.getArrayElement(1).asInt());
         }
     }
+
+    public static class ToReversedTests {
+        @Test
+        public void reversesNumberArrays() {
+            String src = "[41, 42, 43, 44, 45].toReversed();";
+            Integer[] expected = new Integer[]{45, 44, 43, 42, 41};
+
+            testArray(src, expected.length, expected);
+
+            src = "[1, 2, 3, 4, 5].toReversed();";
+            expected = new Integer[]{5, 4, 3, 2, 1};
+
+            testArray(src, expected.length, expected);
+        }
+
+        @Test
+        public void reversesStringArrays() {
+            String src = "['a', 'b', 'c', 'd', 'e'].toReversed();";
+            String[] expected = new String[]{"e", "d", "c", "b", "a"};
+
+            testArray(src, expected.length, expected);
+
+            src = "['abcd', 'hello', 't2xs', 'fge^°'].toReversed();";
+            expected = new String[]{"fge^°", "t2xs", "hello", "abcd"};
+
+            testArray(src, expected.length, expected);
+        }
+
+        @Test
+        public void reverseComplexArray() {
+            String src = "['hello', null, undefined, 0].toReversed();";
+            Object[] expected = new Object[]{0, null, null, "hello"};
+
+            testArray(src, expected.length, expected);
+        }
+
+        private void testArray(String src, long arrayLength, Object[] result) {
+            Context.Builder builder = JSTest.newContextBuilder();
+            builder.option(JSContextOptions.ECMASCRIPT_VERSION_NAME, JSContextOptions.ECMASCRIPT_VERSION_STAGING);
+            try (Context context = builder.build()) {
+                var value = context.eval(JavaScriptLanguage.ID, src);
+                assertEquals(arrayLength, value.getArraySize());
+
+                for (int i = 0; i < arrayLength; i++) {
+                    assertEquals(result[i], value.getArrayElement(i).as(Object.class));
+                }
+            }
+        }
+
+    }
+
 
 }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/ArrayPrototypeBuiltins.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/ArrayPrototypeBuiltins.java
@@ -40,19 +40,6 @@
  */
 package com.oracle.truffle.js.builtins;
 
-import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arrayGetArrayType;
-import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arrayGetLength;
-import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arraySetArrayType;
-import static com.oracle.truffle.js.runtime.builtins.JSArrayBufferView.typedArrayGetLength;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -200,6 +187,19 @@ import com.oracle.truffle.js.runtime.util.Pair;
 import com.oracle.truffle.js.runtime.util.SimpleArrayList;
 import com.oracle.truffle.js.runtime.util.StringBuilderProfile;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arrayGetArrayType;
+import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arrayGetLength;
+import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arraySetArrayType;
+import static com.oracle.truffle.js.runtime.builtins.JSArrayBufferView.typedArrayGetLength;
+
 /**
  * Contains builtins for {@linkplain JSArray}.prototype.
  */
@@ -257,7 +257,10 @@ public final class ArrayPrototypeBuiltins extends JSBuiltinsContainer.SwitchEnum
         groupBy(1),
         groupByToMap(1),
         findLast(1),
-        findLastIndex(1);
+        findLastIndex(1),
+
+        // Next
+        toReversed(0);
 
         private final int length;
 
@@ -366,6 +369,9 @@ public final class ArrayPrototypeBuiltins extends JSBuiltinsContainer.SwitchEnum
                 return JSArrayGroupByNodeGen.create(context, builtin, args().withThis().fixedArgs(2).createArgumentNodes(context));
             case groupByToMap:
                 return JSArrayGroupByToMapNodeGen.create(context, builtin, args().withThis().fixedArgs(2).createArgumentNodes(context));
+
+            case toReversed:
+                return ArrayPrototypeBuiltinsFactory.JSArrayToReversedNodeGen.create(context, builtin, false, args().withThis().fixedArgs(0).createArgumentNodes(context));
         }
         return null;
     }
@@ -2713,6 +2719,26 @@ public final class ArrayPrototypeBuiltins extends JSBuiltinsContainer.SwitchEnum
             }
             reportLoopCount(length);
             return -1;
+        }
+    }
+
+    public abstract static class JSArrayToReversedNode extends JSArrayOperation {
+        public JSArrayToReversedNode(JSContext context, JSBuiltin builtin, boolean isTypedArrayImplementation) {
+            super(context, builtin, isTypedArrayImplementation);
+        }
+
+        @Specialization
+        protected Object reverseArray(final JSDynamicObject thisObj) {
+            Object thisJSObj = toObjectOrValidateTypedArray(thisObj);
+            long length = arrayGetLength(thisObj);
+            Object result = JSArray.createEmpty(getContext(), getRealm(), length);
+
+            for (long i = 0; i < length; i++) {
+                var value = read(thisObj, length-1-i);
+                write(result, i, value);
+            }
+
+            return result;
         }
     }
 

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/ArrayPrototypeBuiltins.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/ArrayPrototypeBuiltins.java
@@ -40,7 +40,6 @@
  */
 package com.oracle.truffle.js.builtins;
 
-import com.oracle.truffle.api.ArrayUtils;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -144,8 +143,6 @@ import com.oracle.truffle.js.nodes.function.JSBuiltinNode;
 import com.oracle.truffle.js.nodes.function.JSFunctionCallNode;
 import com.oracle.truffle.js.nodes.interop.ForeignObjectPrototypeNode;
 import com.oracle.truffle.js.nodes.interop.ImportValueNode;
-import com.oracle.truffle.js.nodes.interop.JSInteropCallNode;
-import com.oracle.truffle.js.nodes.interop.JSInteropExecuteNode;
 import com.oracle.truffle.js.nodes.unary.IsCallableNode;
 import com.oracle.truffle.js.nodes.unary.IsConstructorNode;
 import com.oracle.truffle.js.nodes.unary.JSIsArrayNode;
@@ -161,11 +158,6 @@ import com.oracle.truffle.js.runtime.Symbol;
 import com.oracle.truffle.js.runtime.array.ScriptArray;
 import com.oracle.truffle.js.runtime.array.SparseArray;
 import com.oracle.truffle.js.runtime.array.TypedArray;
-import com.oracle.truffle.js.runtime.array.dyn.AbstractDoubleArray;
-import com.oracle.truffle.js.runtime.array.dyn.AbstractIntArray;
-import com.oracle.truffle.js.runtime.array.dyn.ConstantByteArray;
-import com.oracle.truffle.js.runtime.array.dyn.ConstantDoubleArray;
-import com.oracle.truffle.js.runtime.array.dyn.ConstantIntArray;
 import com.oracle.truffle.js.runtime.builtins.BuiltinEnum;
 import com.oracle.truffle.js.runtime.builtins.JSArray;
 import com.oracle.truffle.js.runtime.builtins.JSArrayBufferView;
@@ -178,7 +170,6 @@ import com.oracle.truffle.js.runtime.builtins.JSMapObject;
 import com.oracle.truffle.js.runtime.builtins.JSOrdinary;
 import com.oracle.truffle.js.runtime.builtins.JSProxy;
 import com.oracle.truffle.js.runtime.builtins.JSSlowArray;
-import com.oracle.truffle.js.runtime.builtins.JSString;
 import com.oracle.truffle.js.runtime.builtins.JSStringObject;
 import com.oracle.truffle.js.runtime.builtins.JSTypedArrayObject;
 import com.oracle.truffle.js.runtime.interop.JSInteropUtil;
@@ -201,7 +192,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.DEFAULT_JSARRAY_COMPARATOR;
 import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arrayGetArrayType;
 import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arrayGetLength;
 import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arraySetArrayType;
@@ -2745,7 +2735,7 @@ public final class ArrayPrototypeBuiltins extends JSBuiltinsContainer.SwitchEnum
             Object result = JSArray.createEmpty(getContext(), getRealm(), length);
 
             for (long i = 0; i < length; i++) {
-                var value = read(array, length-1-i);
+                var value = read(array, length - 1 - i);
                 write(result, i, value);
             }
 
@@ -2803,23 +2793,24 @@ public final class ArrayPrototypeBuiltins extends JSBuiltinsContainer.SwitchEnum
             return result;
         }
 
+        // Arrays.sort has no method to sort a char array _with_ a comparator.
         private void insertionSortCharArray(char[] array, Comparator<Object> comparator) {
             for (int i = 1; i < array.length; i++) {
                 int j = i - 1;
                 char key = array[i];
 
-                while(j >= 0 && comparator.compare(array[j], key) > 0) {
-                    array[j+1] = array[j];
-                    j = j-1;
+                while (j >= 0 && comparator.compare(array[j], key) > 0) {
+                    array[j + 1] = array[j];
+                    j = j - 1;
                 }
 
-                array[j+1] = key;
+                array[j + 1] = key;
             }
         }
 
         private Object sortString(final Object thisJSObj, final Object compare) {
             StringBuilder resultBuilder = new StringBuilder();
-            JSStringObject jsString = (JSStringObject)thisJSObj;
+            JSStringObject jsString = (JSStringObject) thisJSObj;
             String string = jsString.asString();
             Comparator<Object> comparator = compare == null || compare == Undefined.instance ?
                     Comparator.comparing(Object::toString) :

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/ArrayPrototypeBuiltins.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/ArrayPrototypeBuiltins.java
@@ -2725,7 +2725,7 @@ public final class ArrayPrototypeBuiltins extends JSBuiltinsContainer.SwitchEnum
             Object result = JSArray.createEmpty(getContext(), getRealm(), length);
 
             for (long i = 0; i < length; i++) {
-                var value = read(thisObj, length-1-i);
+                var value = read(thisJSObj, length-1-i);
                 write(result, i, value);
             }
 

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/TypedArrayPrototypeBuiltins.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/TypedArrayPrototypeBuiltins.java
@@ -158,7 +158,11 @@ public final class TypedArrayPrototypeBuiltins extends JSBuiltinsContainer.Switc
 
         // ES 2023
         findLast(1),
-        findLastIndex(1);
+        findLastIndex(1),
+
+        // Next
+        toReversed(0),
+        toSorted(1);
 
         private final int length;
 
@@ -243,6 +247,11 @@ public final class TypedArrayPrototypeBuiltins extends JSBuiltinsContainer.Switc
                 return JSArrayIncludesNodeGen.create(context, builtin, true, args().withThis().fixedArgs(2).createArgumentNodes(context));
             case at:
                 return JSArrayAtNodeGen.create(context, builtin, true, args().withThis().fixedArgs(1).createArgumentNodes(context));
+
+            case toReversed:
+                return ArrayPrototypeBuiltinsFactory.JSArrayToReversedNodeGen.create(context, builtin, false, args().withThis().fixedArgs(0).createArgumentNodes(context));
+            case toSorted:
+                return ArrayPrototypeBuiltinsFactory.JSArrayToSortedNodeGen.create(context, builtin, false, args().withThis().fixedArgs(1).createArgumentNodes(context));
         }
         return null;
     }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/sort/SortComparator.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/sort/SortComparator.java
@@ -1,0 +1,79 @@
+package com.oracle.truffle.js.builtins.sort;
+
+import com.oracle.truffle.js.runtime.JSRuntime;
+import com.oracle.truffle.js.runtime.array.ScriptArray;
+import com.oracle.truffle.js.runtime.array.dyn.AbstractDoubleArray;
+import com.oracle.truffle.js.runtime.array.dyn.AbstractIntArray;
+import com.oracle.truffle.js.runtime.array.dyn.ConstantByteArray;
+import com.oracle.truffle.js.runtime.array.dyn.ConstantDoubleArray;
+import com.oracle.truffle.js.runtime.array.dyn.ConstantIntArray;
+import com.oracle.truffle.js.runtime.builtins.JSArray;
+import com.oracle.truffle.js.runtime.builtins.JSFunction;
+import com.oracle.truffle.js.runtime.builtins.JSFunctionObject;
+import com.oracle.truffle.js.runtime.objects.JSDynamicObject;
+import com.oracle.truffle.js.runtime.objects.Undefined;
+
+import java.util.Comparator;
+
+import static com.oracle.truffle.js.runtime.builtins.JSAbstractArray.arrayGetArrayType;
+
+public class SortComparator implements Comparator<Object> {
+    private final Object compFnObj;
+    private final boolean isFunction;
+
+    public SortComparator(Object compFnObj) {
+        this.compFnObj = compFnObj;
+        this.isFunction = JSFunction.isJSFunction(compFnObj);
+    }
+
+    @Override
+    public int compare(Object arg0, Object arg1) {
+        if (arg0 == Undefined.instance) {
+            if (arg1 == Undefined.instance) {
+                return 0;
+            }
+            return 1;
+        } else if (arg1 == Undefined.instance) {
+            return -1;
+        }
+        Object retObj;
+        if (isFunction) {
+            retObj = JSFunction.call((JSFunctionObject) compFnObj, Undefined.instance, new Object[]{arg0, arg1});
+        } else {
+            retObj = JSRuntime.call(compFnObj, Undefined.instance, new Object[]{arg0, arg1});
+        }
+        return convertResult(retObj);
+    }
+
+    private int convertResult(Object retObj) {
+        if (retObj instanceof Integer) {
+            return (int) retObj;
+        } else {
+            double d = JSRuntime.toDouble(retObj);
+            if (d < 0) {
+                return -1;
+            } else if (d > 0) {
+                return 1;
+            } else {
+                // +/-0 or NaN
+                return 0;
+            }
+        }
+    }
+
+    public static Comparator<Object> getDefaultComparator(Object thisObj, boolean isTypedArrayImplementation) {
+        if (isTypedArrayImplementation) {
+            return null; // use Comparable.compareTo (equivalent to Comparator.naturalOrder())
+        } else {
+            if (JSArray.isJSArray(thisObj)) {
+                ScriptArray array = arrayGetArrayType((JSDynamicObject) thisObj);
+                if (array instanceof AbstractIntArray || array instanceof ConstantByteArray || array instanceof ConstantIntArray) {
+                    return JSArray.DEFAULT_JSARRAY_INTEGER_COMPARATOR;
+                } else if (array instanceof AbstractDoubleArray || array instanceof ConstantDoubleArray) {
+                    return JSArray.DEFAULT_JSARRAY_DOUBLE_COMPARATOR;
+                }
+            }
+            return JSArray.DEFAULT_JSARRAY_COMPARATOR;
+        }
+    }
+}

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/sort/SortComparator.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/sort/SortComparator.java
@@ -1,3 +1,43 @@
+/*
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.oracle.truffle.js.builtins.sort;
 
 import com.oracle.truffle.js.runtime.JSRuntime;

--- a/graal-js/test/test262.json
+++ b/graal-js/test/test262.json
@@ -3120,6 +3120,9 @@
     "status" : "FAIL",
     "comment" : "Temporal failures"
   }, {
+    "filePath" : "intl402/DateTimeFormat/prototype/resolvedOptions/order-dayPeriod.js",
+    "status" : "FAIL"
+  }, {
     "filePath" : "intl402/Temporal/Calendar/prototype/dateAdd/date-infinity-throws-rangeerror.js",
     "status" : "FAIL",
     "comment" : "Temporal failures"


### PR DESCRIPTION
I've had some problems getting more complex comparators to work with `toSorted` and strings.
Any ideas on how to fix this, either in this PR or in a separate one, would be highly appreciated.