### PR TITLE
Avoid printing performance warning when initializing GraalJSEngineFactory

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.scriptengine/src/com/oracle/truffle/js/scriptengine/GraalJSEngineFactory.java
+++ b/graal-js/src/com.oracle.truffle.js.scriptengine/src/com/oracle/truffle/js/scriptengine/GraalJSEngineFactory.java
@@ -67,7 +67,7 @@ public final class GraalJSEngineFactory implements ScriptEngineFactory {
     private static final String PLACEHOLDER_VERSION = "1";
 
     static {
-        try (Engine engine = Engine.newBuilder().useSystemProperties(false).build()) {
+        try (Engine engine = Engine.newBuilder().useSystemProperties(false).option("engine.WarnInterpreterOnly", "false").build()) {
             JS_AVAILABLE = engine.getLanguages().containsKey("js");
         }
     }


### PR DESCRIPTION
This a suggestion to fix #763.