### PR TITLE
GraalJSScriptEngine: NPE when setting empty engine bindings

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.scriptengine.test/src/com/oracle/truffle/js/scriptengine/test/TestBindings.java
+++ b/graal-js/src/com.oracle.truffle.js.scriptengine.test/src/com/oracle/truffle/js/scriptengine/test/TestBindings.java
@@ -81,6 +81,22 @@ public class TestBindings {
     }
 
     @Test
+    public void engineEmptyBindings() {
+        ScriptEngine engine = getEngine();
+        Bindings bindings = engine.createBindings();
+        engine.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
+        assertEquals(bindings, engine.getBindings(ScriptContext.ENGINE_SCOPE));
+    }
+
+    @Test
+    public void globalEmptyBindings() {
+        ScriptEngine engine = getEngine();
+        Bindings bindings = engine.createBindings();
+        engine.setBindings(bindings, ScriptContext.GLOBAL_SCOPE);
+        assertEquals(bindings, engine.getBindings(ScriptContext.GLOBAL_SCOPE));
+    }
+
+    @Test
     public void enginePut() throws ScriptException {
         ScriptEngine engine = getEngine();
         engine.put(varName, defaultVarValue);

--- a/graal-js/src/com.oracle.truffle.js.scriptengine/src/com/oracle/truffle/js/scriptengine/GraalJSBindings.java
+++ b/graal-js/src/com.oracle.truffle.js.scriptengine/src/com/oracle/truffle/js/scriptengine/GraalJSBindings.java
@@ -219,7 +219,11 @@ final class GraalJSBindings extends AbstractMap<String, Object> implements Bindi
 
     void updateEngineScriptContext(ScriptContext scriptContext) {
         engineScriptContext = scriptContext;
-        updateContextBinding();
+        if (context != null) {
+            updateContextBinding();
+        } else {
+            initContext(); // This will also call updateContextBinding()
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #839