### PR TITLE
GraalJSScriptEngine: NPE when setting empty engine bindings

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.scriptengine.test/src/com/oracle/truffle/js/scriptengine/test/TestBindings.java
+++ b/graal-js/src/com.oracle.truffle.js.scriptengine.test/src/com/oracle/truffle/js/scriptengine/test/TestBindings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -78,6 +78,22 @@ public class TestBindings {
 
     private ScriptEngine getEngine() {
         return manager.getEngineByName(TestEngine.TESTED_ENGINE_NAME);
+    }
+
+    @Test
+    public void engineEmptyBindings() {
+        ScriptEngine engine = getEngine();
+        Bindings bindings = engine.createBindings();
+        engine.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
+        assertEquals(bindings, engine.getBindings(ScriptContext.ENGINE_SCOPE));
+    }
+
+    @Test
+    public void globalEmptyBindings() {
+        ScriptEngine engine = getEngine();
+        Bindings bindings = engine.createBindings();
+        engine.setBindings(bindings, ScriptContext.GLOBAL_SCOPE);
+        assertEquals(bindings, engine.getBindings(ScriptContext.GLOBAL_SCOPE));
     }
 
     @Test

--- a/graal-js/src/com.oracle.truffle.js.scriptengine/src/com/oracle/truffle/js/scriptengine/GraalJSBindings.java
+++ b/graal-js/src/com.oracle.truffle.js.scriptengine/src/com/oracle/truffle/js/scriptengine/GraalJSBindings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -219,7 +219,11 @@ final class GraalJSBindings extends AbstractMap<String, Object> implements Bindi
 
     void updateEngineScriptContext(ScriptContext scriptContext) {
         engineScriptContext = scriptContext;
-        updateContextBinding();
+        if (context != null) {
+            updateContextBinding();
+        } else {
+            initContext(); // This will also call updateContextBinding()
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #839

Cherry picked from:
69c6c87c8c: GraalJSScriptEngine: NPE when setting empty engine bindings
16d63fa0c2: Correction of the year in the copyright header.

According to our discussion at the GraalVM Community Workshop I'd like to revitalize the `release/graal-vm/23.1` branch and downport this trivial fix which already landed in the [upstream master branch](https://github.com/oracle/graaljs/commit/9f4ce4d24a4b5e6f93d83c4a415d3a399862bdf1).

This fix is required to pass the Java 21 JCK tests if the GraalJS module is bundled (i.e. "jlinked") with the JDK as a system module.