### PR TITLE
Use Double.doubleToRawLongBits() to compare a double with -0.0

### DIFF
--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/math/PowNode.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/math/PowNode.java
@@ -82,7 +82,8 @@ public abstract class PowNode extends MathOperation {
             return a * a;
         } else if (hasSeenThree && b == 3) {
             return a * a * a;
-        } else if ((hasSeenZeroPointFive || hasSeenOnePointFive || hasSeenTwoPointFive) && (a < 0.0 || a == -0.0)) {
+        } else if ((hasSeenZeroPointFive || hasSeenOnePointFive || hasSeenTwoPointFive) &&
+                   (a < 0.0 || JSRuntime.isNegativeZero(a))) {
             // sqrt behaves differently, counter example is Math.pow(-Infinity,0.5)
             return powIntl(a, b);
         } else if (hasSeenZeroPointFive && b == 0.5) {
@@ -143,7 +144,7 @@ public abstract class PowNode extends MathOperation {
         int ib = (int) b;
         if (branch1.profile(this, JSRuntime.doubleIsRepresentableAsInt(b, true) && b > 0)) {
             return positivePow(a, ib);
-        } else if (branch2.profile(this, ib + 0.5 == b && b > 0 && a > 0 && a != -0.0)) {
+        } else if (branch2.profile(this, ib + 0.5 == b && b > 0 && a > 0 && !JSRuntime.isNegativeZero(a))) {
             return positivePow(a, ib) * Math.sqrt(a);
         } else {
             return powIntl(a, b);


### PR DESCRIPTION
In `PowNode::pow()` there are optimizations for specific input values which map `pow()` to the cheaper `sqrt()` function. But for some double inputs like `-0.0` this mapping is not valid and has to be excluded.

However, we can not simply compare a double value `d` with `-0.0` because the JLS (and the IEEE 754 standard) require that positive and negative zeros are considered equal and therefor `0.0 == -0.0`.

In order to really check for a negative zero we have to use `Double.doubleToRawLongBits()`.