### PR TITLE
Specialize for-of on foreign objects

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.parser/src/com/oracle/truffle/js/parser/GraalJSTranslator.java
+++ b/graal-js/src/com.oracle.truffle.js.parser/src/com/oracle/truffle/js/parser/GraalJSTranslator.java
@@ -2195,7 +2195,7 @@ abstract class GraalJSTranslator extends com.oracle.js.parser.ir.visitor.Transla
             wrappedBody = factory.createIteratorCloseWrapper(context, wrappedBody, iteratorVar.createReadNode(), false);
         }
 
-        RepeatingNode repeatingNode = factory.createForOfRepeatingNode(iteratorNext, wrappedBody,
+        RepeatingNode repeatingNode = factory.createForOfRepeatingNode(forNode.isForOf(), forNode.isForAwaitOf(), iteratorVar.createReadNode(), iteratorNext, wrappedBody,
                         (JSWriteFrameSlotNode) nextResultVar.createWriteNode(null));
         LoopNode loopNode = factory.createLoopNode(repeatingNode);
         JavaScriptNode whileNode = forNode.isForOf()

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/NodeFactory.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/NodeFactory.java
@@ -537,8 +537,9 @@ public class NodeFactory {
         return WhileNode.createDesugaredForAwaitOf(loopNode);
     }
 
-    public RepeatingNode createForOfRepeatingNode(JavaScriptNode nextResultNode, JavaScriptNode body, JSWriteFrameSlotNode writeNextValueNode) {
-        return WhileNode.createForOfRepeatingNode(nextResultNode, body, writeNextValueNode);
+    public RepeatingNode createForOfRepeatingNode(boolean isForOf, boolean isForOfAsync, JavaScriptNode iteratorNode, JavaScriptNode nextResultNode, JavaScriptNode body,
+                    JSWriteFrameSlotNode writeNextValueNode) {
+        return WhileNode.createForOfRepeatingNode(isForOf, isForOfAsync, iteratorNode, nextResultNode, body, writeNextValueNode);
     }
 
     public RepeatingNode createForRepeatingNode(JavaScriptNode condition, JavaScriptNode body, JavaScriptNode modify, FrameDescriptor frameDescriptor, JavaScriptNode isFirstNode,


### PR DESCRIPTION
Can I please get some reviews of this patch to specialize `for .. of` loops on foreign objects? The idea explored here is that by adding this specialization some of the calls on the loop Iterator can be bypassed. In some of our benchmarks we obtained over 10% improvement with this change.

Tested on our internal benchmarks and with `mx gate`.

