### PR TITLE
Best effort Module Resolution Algorithm implementation based on Node.js 25.2.1

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json-simple/index.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json-simple/index.js
@@ -1,0 +1,1 @@
+export let name = "index";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json-simple/package.json
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json-simple/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "exports-in-package-simple",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "type": "module",
+  "author": "",
+  "license": "UPL",
+  "exports": "./index.js"
+}

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/feature-graaljs.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/feature-graaljs.js
@@ -1,0 +1,1 @@
+export let name = "graaljs"

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/feature-node.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/feature-node.js
@@ -1,0 +1,1 @@
+export let name = "node";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/index.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/index.js
@@ -1,0 +1,1 @@
+export let name = "index";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/not-exported.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/not-exported.js
@@ -1,0 +1,1 @@
+export let name = "not-exported";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/package.json
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-in-package-json/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "exports-in-package",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "type": "module",
+  "author": "",
+  "license": "UPL",
+  "exports": {
+    ".": "./index.js",
+    "./feature.js": {
+      "node": "./feature-node.js",
+      "graaljs": "./feature-graaljs.js",
+      "default": "./feature.js"
+    },
+    "./feature-noncompatible.js": {
+      "noncompatible": "./feature-node.js"
+    }
+  }
+}

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/cjs/feature-graaljs.cjs
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/cjs/feature-graaljs.cjs
@@ -1,0 +1,1 @@
+module.exports.name = "cjs-graaljs"

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/cjs/feature-node.cjs
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/cjs/feature-node.cjs
@@ -1,0 +1,1 @@
+module.exports.name = "cjs-node"

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/cjs/feature.cjs
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/cjs/feature.cjs
@@ -1,0 +1,1 @@
+module.exports.name = "cjs-default";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/esm/feature-graaljs.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/esm/feature-graaljs.js
@@ -1,0 +1,1 @@
+export let name = "esm-graaljs";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/esm/feature-node.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/esm/feature-node.js
@@ -1,0 +1,1 @@
+export let name = "esm-node";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/esm/feature.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/esm/feature.js
@@ -1,0 +1,1 @@
+export let name = "esm-default";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/package.json
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-nested/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "exports-nest",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "type": "module",
+  "author": "",
+  "license": "UPL",
+  "exports": {
+    ".": "./index.js",
+    "./feature.js": {
+      "node": {
+        "import": "./esm/feature-node.js",
+        "require": "./cjs/feature-node.cjs"
+      },
+      "graaljs": {
+        "import": "./esm/feature-graaljs.js",
+        "require": "./cjs/feature-node.cjs"
+      },
+      "default": "./cjs/feature.cjs"
+    },
+    "./should-default.js": {
+      "graaljs": {
+        "nonexistence": "./nonexistence.js"
+      },
+      "default": "./esm/feature.js"
+    },
+    "./should-default-cjs": {
+      "default": "./cjs/feature.cjs"
+    },
+    "./exports-array": [
+      "./esm/feature-node.js",
+      "./cjs/feature-node.cjs"
+    ]
+  }
+}

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-extensions/lib/helper.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-extensions/lib/helper.js
@@ -1,0 +1,1 @@
+export const name = "helper";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-extensions/lib/index.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-extensions/lib/index.js
@@ -1,0 +1,1 @@
+export const name = "index"

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-extensions/package.json
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-extensions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "my-package",
+  "type": "module",
+  "exports": {
+    ".": "./lib/index.js",
+    "./lib": "./lib/index.js",
+    "./lib/*": "./lib/*.js",
+    "./lib/*.js": "./lib/*.js"
+  }
+}

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest-feature/feature-graaljs.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest-feature/feature-graaljs.js
@@ -1,0 +1,1 @@
+export let name = "dest-feature-graaljs"

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest-feature/feature-import.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest-feature/feature-import.js
@@ -1,0 +1,1 @@
+export let name = "dest-feature-import";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest-feature/feature-node.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest-feature/feature-node.js
@@ -1,0 +1,1 @@
+export let name = "dest-feature-node";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest/index.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest/index.js
@@ -1,0 +1,1 @@
+export let name = "dest-index";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest/main.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/dest/main.js
@@ -1,0 +1,1 @@
+export let name = "dest-main";

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/package.json
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/exports-subpath-pattern/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "exports-in-package",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "type": "module",
+  "author": "",
+  "license": "UPL",
+  "exports": {
+    ".": "./dest/index.js",
+    "./src": "./dest/index.js",
+    "./src/*.js": "./dest/*.js",
+    "./src-feature": "./dest-feature/index.js",
+    "./src-feature/*.js": {
+      "import": {
+        "graaljs": "./dest-feature/*-graaljs.js",
+        "node": "./dest-feature/*-node.js"
+      },
+      "require": "./dest-feature/*-require.js"
+    }
+  }
+}

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports-external/dep.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports-external/dep.js
@@ -1,0 +1,2 @@
+const name = "dep-external";
+export default name;

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports-external/package.json
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports-external/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "./dep.js"
+}

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports/dep.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports/dep.js
@@ -1,0 +1,2 @@
+const name = "dep";
+export default name;

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports/import-external.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports/import-external.js
@@ -1,0 +1,3 @@
+import dep_name from "#dep-external" ;
+
+export const name = dep_name;

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports/main.js
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports/main.js
@@ -1,0 +1,3 @@
+import dep_name from "#dep" ;
+
+export const name = dep_name;

--- a/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports/package.json
+++ b/graal-js/src/com.oracle.truffle.js.test/commonjs/node_modules/subpath-imports/package.json
@@ -1,0 +1,15 @@
+{
+  "type": "module",
+  "imports": {
+    "#dep": {
+      "default": "./dep.js"
+    },
+    "#dep-external": {
+      "default": "subpath-imports-external"
+    }
+  },
+  "exports": {
+    ".": "./main.js",
+    "./external": "./import-external.js"
+  }
+}

--- a/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/CommonJSRequireTest.java
+++ b/graal-js/src/com.oracle.truffle.js.test/src/com/oracle/truffle/js/test/builtins/CommonJSRequireTest.java
@@ -695,10 +695,9 @@ public class CommonJSRequireTest {
     }
 
     @Test
-    public void dontImportCommonJs() throws IOException {
-        final String src = "import('with-package').then(x => {throw 'unexpected'}).catch(console.log);";
-        final String out = "TypeError: Unsupported file extension: '" + getTestRootFolderUrl() + "node_modules/with-package/alternative-index.js'\n";
-        runAndExpectOutput(src, out);
+    public void dynamicImportCommonJs() throws IOException {
+        final String src = "import('with-package').then(x => {console.log(x.foo)}).catch(console.log);";
+        runAndExpectOutput(src, "42\n");
     }
 
     @Test
@@ -803,5 +802,174 @@ public class CommonJSRequireTest {
             }
             assertEquals(expectedMessage, t.getMessage());
         }
+    }
+
+    @Test
+    public void importModuleFromExportsFieldSimple() throws IOException {
+        final String src = "import {name} from 'exports-in-package-json-simple'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "index\n", options);
+    }
+
+    @Test
+    public void importModuleFromExportsFieldSimpleThrow() {
+        final String src = "import {name} from 'exports-in-package-json-simple/index.js'; console.log('should throw')";
+        final String expectedMessage = "TypeError: Package subpath is not defined by \"exports\" field: './index.js'";
+        Map<String, String> options = getDefaultOptions();
+        try {
+            runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "index\n", options);
+            assert false;
+        } catch (Throwable t) {
+            if (!t.getClass().isAssignableFrom(PolyglotException.class)) {
+                throw new AssertionError("Unexpected exception " + t);
+            }
+            assertEquals(expectedMessage, t.getMessage());
+        }
+    }
+
+    @Test
+    public void subpathImports() throws IOException {
+        final String src = "import {name} from 'subpath-imports'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "dep\n", options);
+    }
+
+    @Test
+    public void subpathImportsExternal() throws IOException {
+        final String src = "import {name} from 'subpath-imports/external'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "dep-external\n", options);
+    }
+
+    @Test
+    public void importModuleFromExportsField() throws IOException {
+        final String src = "import {name} from 'exports-in-package-json'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "index\n", options);
+    }
+
+    @Test
+    public void importModuleFromExportsField2() throws IOException {
+        final String src = "import {name} from 'exports-in-package-json/feature.js'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "graaljs\n", options);
+    }
+
+    @Test
+    public void importModuleCustomCondition() throws IOException {
+        final String src = "import {name} from 'exports-in-package-json/feature.js'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        options.put("js.commonjs-require-user-conditions", "browser,node");
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "node\n", options);
+    }
+
+    @Test
+    public void importModuleFromExportsPriorityThrow() {
+        final String src = "import {name} from 'exports-in-package-json/feature-noncompatible.js'; console.log('should throw')";
+        final String expectedMessage = "TypeError: Package subpath is not defined by \"exports\" field: './feature-noncompatible.js'";
+        Map<String, String> options = getDefaultOptions();
+        try {
+            runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "", options);
+            assert false;
+        } catch (Throwable t) {
+            if (!t.getClass().isAssignableFrom(PolyglotException.class)) {
+                throw new AssertionError("Unexpected exception " + t);
+            }
+            assertEquals(expectedMessage, t.getMessage());
+        }
+    }
+
+    @Test
+    public void importModuleFromExportsNotExported() {
+        final String src = "import {name} from 'exports-in-package-json/not-exported.js'; console.log('should throw')";
+        final String expectedMessage = "TypeError: Package subpath is not defined by \"exports\" field: './not-exported.js'";
+        Map<String, String> options = getDefaultOptions();
+        try {
+            runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "", options);
+            assert false;
+        } catch (Throwable t) {
+            if (!t.getClass().isAssignableFrom(PolyglotException.class)) {
+                throw new AssertionError("Unexpected exception " + t);
+            }
+            assertEquals(expectedMessage, t.getMessage());
+        }
+    }
+
+    @Test
+    public void importModulePatternWithoutExtension() throws IOException {
+        final String src = "import {name} from 'exports-subpath-extensions/lib/index'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "index\n", options);
+    }
+
+    @Test
+    public void importModulePatternWithExtension() throws IOException {
+        final String src = "import {name} from 'exports-subpath-extensions/lib/index.js'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "index\n", options);
+    }
+
+    private Source subpathPatternTestBuildSrc(String name) {
+        try {
+            String src = "import {name} from 'exports-subpath-pattern" + (name == "" ? "" : "/" + name) + "'; console.log(name)";
+            return Source.newBuilder(ID, src, "test.mjs").build();
+        } catch (IOException e) {
+            throw new AssertionError("Unexpected exception " + e);
+        }
+    }
+
+    @Test
+    public void importModuleSubpathPattern() throws IOException {
+        var options = getDefaultOptions();
+        runAndExpectOutput(this.subpathPatternTestBuildSrc("src/main.js"), "dest-main\n", options);
+    }
+
+    @Test
+    public void importModuleSubpathPatternWithConditional() throws IOException {
+        var options = getDefaultOptions();
+        runAndExpectOutput(this.subpathPatternTestBuildSrc("src-feature/feature.js"), "dest-feature-graaljs\n", options);
+    }
+
+    @Test
+    public void importModuleSubpathPatternThrow() {
+        var options = getDefaultOptions();
+        final String expectedMessage = "TypeError: Module not found: 'exports-subpath-pattern/src-feature/nonexistence.js'";
+        try {
+            runAndExpectOutput(this.subpathPatternTestBuildSrc("src-feature/nonexistence.js"), "", options);
+            assert false;
+        } catch (Throwable t) {
+            if (!t.getClass().isAssignableFrom(PolyglotException.class)) {
+                throw new AssertionError("Unexpected exception " + t);
+            }
+            assertEquals(expectedMessage, t.getMessage());
+        }
+    }
+
+    @Test
+    public void importModuleNestExports() throws IOException {
+        final String src = "import {name} from 'exports-nested/feature.js'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "esm-graaljs\n", options);
+    }
+
+    @Test
+    public void importModuleFromExportsArray() throws IOException {
+        final String src = "import {name} from 'exports-nested/exports-array'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "esm-node\n", options);
+    }
+
+    @Test
+    public void importModuleNestExportsShouldDefault() throws IOException {
+        final String src = "import {name} from 'exports-nested/should-default.js'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "esm-default\n", options);
+    }
+
+    @Test
+    public void importModuleExportsDefaultToCjs() throws IOException {
+        final String src = "import {name} from 'exports-nested/should-default-cjs'; console.log(name)";
+        Map<String, String> options = getDefaultOptions();
+        runAndExpectOutput(Source.newBuilder(ID, src, "test.mjs").build(), "cjs-default\n", options);
     }
 }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/NpmCompatibleESModuleLoader.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/NpmCompatibleESModuleLoader.java
@@ -53,18 +53,19 @@ import static com.oracle.truffle.js.builtins.commonjs.CommonJSResolution.joinPat
 import static com.oracle.truffle.js.builtins.commonjs.CommonJSResolution.loadJsonObject;
 import static com.oracle.truffle.js.lang.JavaScriptLanguage.ID;
 import static com.oracle.truffle.js.runtime.Strings.EXPORTS_PROPERTY_NAME;
-import static com.oracle.truffle.js.runtime.Strings.MODULE;
+import static com.oracle.truffle.js.runtime.Strings.IMPORTS_PROPERTY_NAME;
 import static com.oracle.truffle.js.runtime.Strings.NAME;
 import static com.oracle.truffle.js.runtime.Strings.PACKAGE_JSON_MAIN_PROPERTY_NAME;
 import static com.oracle.truffle.js.runtime.Strings.TYPE;
+import static com.oracle.truffle.js.runtime.Strings.constant;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import com.oracle.js.parser.ir.Module.ModuleRequest;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -77,7 +78,9 @@ import com.oracle.truffle.js.runtime.JSArguments;
 import com.oracle.truffle.js.runtime.JSErrorType;
 import com.oracle.truffle.js.runtime.JSException;
 import com.oracle.truffle.js.runtime.JSRealm;
+import com.oracle.truffle.js.runtime.JSRuntime;
 import com.oracle.truffle.js.runtime.Strings;
+import com.oracle.truffle.js.runtime.array.ScriptArray;
 import com.oracle.truffle.js.runtime.builtins.JSFunction;
 import com.oracle.truffle.js.runtime.builtins.JSFunctionObject;
 import com.oracle.truffle.js.runtime.objects.AbstractModuleRecord;
@@ -95,36 +98,28 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
     private static final URI TryCommonJS = URI.create("custom:///try-common-js-token");
     private static final URI TryCustomESM = URI.create("custom:///try-custom-esm-token");
 
+    private static final String TYPE_MODULE = "module";
+    private static final String TYPE_COMMONS_JS = "commonjs";
     private static final String MODULE_NOT_FOUND = "Module not found: '";
     private static final String UNSUPPORTED_JSON = "JSON packages not supported.";
     private static final String FAILED_BUILTIN = "Failed to load built-in ES module: '";
     private static final String INVALID_MODULE_SPECIFIER = "Invalid module specifier: '";
     private static final String UNSUPPORTED_FILE_EXTENSION = "Unsupported file extension: '";
-    private static final String UNSUPPORTED_PACKAGE_EXPORTS = "Unsupported package exports: '";
-    private static final String INVALID_PACKAGE_EXPORT = "Invalid package export: ";
-    private static final String UNSUPPORTED_PACKAGE_IMPORTS = "Unsupported package imports: '";
+    private static final String INVALID_PACKAGE_TARGET = "Invalid package export: '";
+    private static final String PACKAGE_PATH_NOT_EXPORTED = "Package subpath is not defined by \"exports\" field: '";
+    private static final String PACKAGE_IMPORT_NOT_DEFINED = "Packages imports do not define the specifier: '";
     private static final String UNSUPPORTED_DIRECTORY_IMPORT = "Unsupported directory import: '";
     private static final String INVALID_PACKAGE_CONFIGURATION = "Invalid package configuration: '";
-    private static final String EXPORT_TYPE_GRAALJS = "graaljs";
-    private static final String EXPORT_TYPE_IMPORT = "import";
-    private static final String EXPORT_TYPE_REQUIRE = "require";
-    private static final String EXPORT_TYPE_DEFAULT = "default";
-    private static final LinkedList<String> EXPORT_TYPES;
+    private static final String CONDITION_TYPE_GRAALJS = "graaljs";
+    private static final String CONDITION_TYPE_IMPORT = "import";
+    private static final String CONDITION_TYPE_REQUIRE = "require";
+    private static final String CONDITION_TYPE_DEFAULT = "default";
+    private static final char PACKAGE_EXPORT_WILDCARD = '*';
+    private static final List<String> DEFAULT_CONDITIONS = List.of(CONDITION_TYPE_GRAALJS, CONDITION_TYPE_IMPORT, CONDITION_TYPE_REQUIRE, CONDITION_TYPE_DEFAULT);
 
-    static {
-        EXPORT_TYPES = new LinkedList<>(
-                List.of(EXPORT_TYPE_GRAALJS, EXPORT_TYPE_IMPORT, EXPORT_TYPE_REQUIRE, EXPORT_TYPE_DEFAULT)
-        );
-    }
-
-    public static void registerPreferredExportType(String exportType) {
-        if (!EXPORT_TYPES.contains(exportType)) {
-            EXPORT_TYPES.addFirst(exportType);
-        }
-    }
-
-    public static List<String> getRegisteredExportTypes() {
-        return List.copyOf(EXPORT_TYPES);
+    public List<String> getConditions() {
+        return Stream.concat(this.realm.getContextOptions().getUserConditions().stream(),
+                        DEFAULT_CONDITIONS.stream()).toList();
     }
 
     public static NpmCompatibleESModuleLoader create(JSRealm realm) {
@@ -158,21 +153,35 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
             TruffleLanguage.Env env = realm.getEnv();
             URI parentURL = getFullPath(referencingModule).toUri();
             URI resolution = esmResolve(specifier, parentURL, env);
-            if (resolution == TryCommonJS) {
+            Format format;
+
+            // If resolved is a "file:" URL, then
+            if (isFileURI(resolution)) {
+                // Set format to the result of ESM_FILE_FORMAT(resolved).
+                format = esmFileFormat(resolution, env);
+            } else {
+                // Set format the module format of the content type associated with the URL
+                // resolved.
+                format = getAssociatedDefaultFormat(resolution);
+            }
+
+            if (resolution == TryCustomESM) {
+                // Failed ESM resolution. Give the virtual FS a chance to map to a file.
+                // A custom Truffle FS might still try to map a package specifier to some file.
+                TruffleFile maybeFile = env.getPublicTruffleFile(specifier);
+                if (maybeFile.exists() && !maybeFile.isDirectory()) {
+                    return loadModuleFromFile(referencingModule, moduleRequest, maybeFile, maybeFile.getPath());
+                }
+            } else if (isFileURI(resolution) && format == Format.CommonJS) {
+                // If esmResolve returns a valid file url and the format is CommonJS,
+                // we will use this path to load the CJS module.
+                return tryLoadingAsCommonjsModule(resolution.getRawPath());
+            } else if (resolution == TryCommonJS || format == Format.CommonJS) {
                 // Compatibility mode: try loading as a CommonJS module.
                 return tryLoadingAsCommonjsModule(specifier);
-            } else {
-                if (resolution == TryCustomESM) {
-                    // Failed ESM resolution. Give the virtual FS a chance to map to a file.
-                    // A custom Truffle FS might still try to map a package specifier to some file.
-                    TruffleFile maybeFile = env.getPublicTruffleFile(specifier);
-                    if (maybeFile.exists() && !maybeFile.isDirectory()) {
-                        return loadModuleFromFile(referencingModule, moduleRequest, maybeFile, maybeFile.getPath());
-                    }
-                } else if (resolution != null) {
-                    TruffleFile file = env.getPublicTruffleFile(resolution);
-                    return loadModuleFromFile(referencingModule, moduleRequest, file, file.getPath());
-                }
+            } else if (resolution != null) {
+                TruffleFile file = env.getPublicTruffleFile(resolution);
+                return loadModuleFromFile(referencingModule, moduleRequest, file, file.getPath());
             }
             // Really could not load as ESM.
             throw fail(MODULE_NOT_FOUND, specifier);
@@ -265,7 +274,7 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
     //
     // #### ESM resolution algorithm emulation.
     //
-    // Best-effort implementation based on Node.js' v16.15.0 resolution algorithm.
+    // Best-effort implementation based on Node.js' v25.2.1 resolution algorithm.
     //
 
     /**
@@ -283,7 +292,9 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
                 resolved = resolveRelativeToParent(specifier, parentURL);
             } else if (!specifier.isEmpty() && specifier.charAt(0) == '#') {
                 // 4. Otherwise, if specifier starts with "#", then
-                throw fail(UNSUPPORTED_PACKAGE_IMPORTS, specifier);
+                // 4.1 Set resolved to the result of PACKAGE_IMPORTS_RESOLVE(specifier, parentURL,
+                // defaultConditions).
+                resolved = packageImportsResolve(specifier, parentURL, getConditions(), env);
             } else {
                 // 5.1 Note: specifier is now a bare specifier.
                 // 5.2 Set resolvedURL the result of PACKAGE_RESOLVE(specifier, parentURL).
@@ -297,8 +308,6 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
             // Try customFS lookup
             return resolved;
         }
-        // 6. Let format be undefined.
-        Format format;
         // 7. If resolved is a "file:" URL, then
         if (isFileURI(resolved)) {
             // 7.1 If resolvedURL contains any percent encodings of "/" or "\" ("%2f" and "%5C"
@@ -320,21 +329,44 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
             // 7.4 Set resolved to the real path of resolved, maintaining the same URL querystring
             // and fragment components.
             resolved = resolved.normalize();
-            // 7.5 Set format to the result of ESM_FILE_FORMAT(resolved).
-            format = esmFileFormat(resolved, env);
-        } else {
-            // 8. Otherwise
-            // 8.1 Set format the module format of the content type associated with the URL
-            // resolved.
-            format = getAssociatedDefaultFormat(resolved);
         }
-        if (format == Format.CommonJS) {
-            // Will load as CommonJS.
-            return TryCommonJS;
-        } else {
-            // Will load as ESM.
-            return resolved;
+        return resolved;
+    }
+    /*
+     * PACKAGE_IMPORTS_RESOLVE(specifier, parentURL, conditions)
+     */
+
+    private URI packageImportsResolve(String specifier, URI parentURL, List<String> conditions, TruffleLanguage.Env env) {
+        // 1. Assert: specifier begins with "#" (it is always called with a specifier that begins
+        // with "#").
+        // 2. If specifier is exactly equal to "#", then
+        if (specifier.equals("#")) {
+            // 2.1 Throw an Invalid Module Specifier error.
+            throw fail(INVALID_MODULE_SPECIFIER, specifier);
         }
+        // 3. Let packageURL be the result of LOOKUP_PACKAGE_SCOPE (parentURL).
+        var packageURL = lookupPackageScope(parentURL, env);
+        // 4. If packageURL is not null, then
+        if (packageURL != null) {
+            // 4.1 Let pjson be the result of READ_PACKAGE_JSON(packageURL).
+            PackageJson pjson = readPackageJson(packageURL, env);
+            // 4.2 If pjson.imports is a non-null Object, then
+            if (pjson != null && pjson.hasImportsProperty()) {
+                JSDynamicObject imports = pjson.getImportsProperty();
+                if (imports != null) {
+                    // 4.2.1 Let resolved be the result of
+                    // PACKAGE_IMPORTS_EXPORTS_RESOLVE(specifier, pjson.imports, packageURL, true,
+                    // conditions).
+                    URI resolved = packageImportsExportsResolve(specifier, imports, packageURL, true, conditions, env);
+                    // 4.2.2 If resolved is not null or undefined, return resolved.
+                    if (resolved != null) {
+                        return resolved;
+                    }
+                }
+            }
+        }
+        // 5. Throw a Package Import Not Defined error.
+        throw fail(PACKAGE_IMPORT_NOT_DEFINED, specifier);
     }
 
     /**
@@ -356,49 +388,322 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
         if (url.getPath().endsWith(JSON_EXT)) {
             throw failMessage(UNSUPPORTED_JSON);
         }
-        // 5. Let packageURL be the result of LOOKUP_PACKAGE_SCOPE(url).
+        // - 5. If url ends in ".wasm", then
+        // - 6. If --experimental-addon-modules is enabled and url ends in ".node", then
+        // 7. Let packageURL be the result of LOOKUP_PACKAGE_SCOPE(url).
         URI packageUri = lookupPackageScope(url, env);
+        PackageJson pjson = null;
         if (packageUri != null) {
-            // 6. Let pjson be the result of READ_PACKAGE_JSON(packageURL).
-            PackageJson pjson = readPackageJson(packageUri, env);
-            // 7. If pjson?.type exists and is "module", then
-            if (pjson != null && pjson.hasTypeModule()) {
-                // 7.1 If url ends in ".js", then Return "module"
-                if (url.getPath().endsWith(JS_EXT)) {
-                    return Format.ESM;
-                }
-            } else if (url.getPath().endsWith(JS_EXT)) {
-                // Np Fallback to CJS as below (in the case that there is a package.json without a "type" field, or
-                // the "type" field is not "module").
-                return Format.CommonJS;
+            // 8. Let pjson be the result of READ_PACKAGE_JSON(packageURL).
+            pjson = readPackageJson(packageUri, env);
+        }
+        // 9. Let packageType be null
+        String packageType = null;
+        if (pjson != null) {
+            // 10. If pjson?.type is "module" or "commonjs", then
+            if (pjson.hasTypeProperty()) {
+                // 10.1 Set packageType to pjson.type.
+                packageType = pjson.getTypeProperty();
             }
-        } else if (url.getPath().endsWith(JS_EXT)) {
-            // Np Package.json with .js extension: try loading as CJS like Node.js does.
+        }
+        // 11. If url ends in ".js", then
+        if (url.getPath().endsWith(JS_EXT)) {
+            // 11.1 If packageType is not null, then
+            if (packageType != null) {
+                // 11.1.1 Return packageType.
+                if (packageType.equals(TYPE_MODULE)) {
+                    return Format.ESM;
+                } else {
+                    return Format.CommonJS;
+                }
+            }
+            // 11.2 If the result of DETECT_MODULE_SYNTAX(source) is true, then
+            // not implemented
+            // 11.3 Return "commonjs"
             return Format.CommonJS;
         }
-        // 8. Otherwise, Throw an Unsupported File Extension error.
+        // 12. If url does not have any extension, then
+        // not implemented
         throw fail(UNSUPPORTED_FILE_EXTENSION, url.toString());
     }
 
-    private URI exportForImport(URI packageUrl, Map<String, String> exports, TruffleLanguage.Env env) {
-        // in order of preference, find the best import to use for this circumstance; this will be `graaljs` if
-        // specified (as top preference), then `import`, then `require`, then `default`. if the developer has registered
-        // their own preferred export types, these will be preferred first.
-        //
-        // this branch only activates if package exports are present and need to be used to resolve an import. thus,
-        // there is no fallback behavior waiting for us, and so an exception is thrown if no export can be matched.
-
-        // 1. for preferred export types...
-        for (String preferred : getRegisteredExportTypes()) {
-            // 1.1: is it specified within the exports?
-            if (exports.containsKey(preferred)) {
-                // 1.2: if so, resolve the import from the package root. make sure to slice off the `./` prefix.
-                return packageUrl.resolve(exports.get(preferred).substring(2));
+    /**
+     * PACKAGE_EXPORTS_RESOLVE(packageURL, subpath, exports, conditions)
+     */
+    private URI packageExportsResolve(URI packageURL, String subpath, Object exports, List<String> conditions, TruffleLanguage.Env env) {
+        URI resolved = null;
+        // 1. If exports is an Object with both a key starting with "." and a key not starting with
+        // ".",
+        // throw an Invalid Package Configuration error.
+        boolean hasStartingWithDot = false;
+        if (exports instanceof JSDynamicObject exportsObj) {
+            List<Object> keys = JSObject.ownPropertyKeys(exportsObj);
+            for (int i = 0; i < keys.size(); i++) {
+                var keyTStr = keys.get(i);
+                var keyStr = keyTStr.toString();
+                boolean startingWithDot = keyStr.startsWith(".");
+                // If exports is an Object with both a key starting with "." and a key not starting
+                // with ".", throw an Invalid Package Configuration error.
+                if (i != 0 && hasStartingWithDot != startingWithDot) {
+                    throw fail(INVALID_PACKAGE_CONFIGURATION, packageURL.toString());
+                }
+                hasStartingWithDot = startingWithDot;
             }
         }
+        // 2. If subpath is equal to ".", then
+        if (subpath.equals(".")) {
+            // 2.1 Let mainExport be undefined
+            Object mainExport = null;
+            // 2.2 If exports is a String or Array,
+            // or an Object containing no keys starting with ".", then
+            if (exports instanceof TruffleString || (exports instanceof JSDynamicObject && !hasStartingWithDot) || JSObject.hasArray(exports)) {
+                mainExport = exports;
+                // 2.3 Otherwise if exports is an Object containing a "." property, then
+            } else if (exports instanceof JSDynamicObject exportsObj &&
+                            exportsObj.hasOwnProperty(Strings.DOT)) {
+                // 2.3.1 Set mainExport to exports["."].
+                mainExport = JSObject.get(exportsObj, Strings.DOT);
+            }
+            // 2.4 If mainExport is not undefined, then
+            if (mainExport != null) {
+                // 2.4.1 Let resolved be the result of PACKAGE_TARGET_RESOLVE(packageURL,
+                // mainExport, null, false, conditions).
+                resolved = packageTargetResolve(packageURL, mainExport, null, false, conditions, env);
+                // 2.4.2 If resolved is not null or undefined, return resolved.
+                if (resolved != null) {
+                    return resolved;
+                }
+            }
+        } else {
+            // 3. Otherwise, if exports is an Object and all keys of exports start with ".", then
+            if (exports instanceof JSDynamicObject exportsObj && hasStartingWithDot) {
+                // 3.1 Assert: subpath begins with "./".
+                if (!subpath.startsWith("./")) {
+                    throw fail(INVALID_MODULE_SPECIFIER, subpath);
+                }
+                // 3.2 Let resolved be the result of PACKAGE_IMPORTS_EXPORTS_RESOLVE( subpath,
+                // exports, packageURL, false, conditions).
+                resolved = packageImportsExportsResolve(subpath, exportsObj, packageURL, false, conditions, env);
+                // 3.3 If resolved is not null or undefined, return resolved.
+                if (resolved != null) {
+                    return resolved;
+                }
+            }
+        }
+        // 4. Throw a Package Path Not Exported error.
+        throw fail(PACKAGE_PATH_NOT_EXPORTED, subpath);
+    }
 
-        // 2. if no preferred export types are specified, or none of them are found, throw an exception.
-        throw failMessage(UNSUPPORTED_PACKAGE_EXPORTS);
+    private static boolean containsOnlyOne(String s, char c) {
+        int first = s.indexOf(c);
+        return (first != -1) && (first == s.lastIndexOf(c));
+    }
+
+    /**
+     * PATTERN_KEY_COMPARE(keyA, keyB)
+     */
+    private static int patternKeyCompare(String keyA, String keyB, URI packageURL) {
+        // 1. Assert: keyA contains only a single "*".
+        // 2. Assert: keyB contains only a single "*".
+        if (!containsOnlyOne(keyA, PACKAGE_EXPORT_WILDCARD) || !containsOnlyOne(keyB, PACKAGE_EXPORT_WILDCARD)) {
+            throw fail(INVALID_PACKAGE_TARGET, packageURL.toString());
+        }
+        // 3. Let baseLengthA be the index of "*" in keyA.
+        var baseLengthA = keyA.indexOf(PACKAGE_EXPORT_WILDCARD);
+        // 4. Let baseLengthB be the index of "*" in keyB.
+        var baseLengthB = keyB.indexOf(PACKAGE_EXPORT_WILDCARD);
+        // 5. If baseLengthA is greater than baseLengthB, return -1.
+        if (baseLengthA > baseLengthB) {
+            return -1;
+        }
+        // 6. If baseLengthB is greater than baseLengthA, return 1.
+        if (baseLengthB > baseLengthA) {
+            return 1;
+        }
+        // 7. If the length of keyA is greater than the length of keyB, return -1.
+        if (keyA.length() > keyB.length()) {
+            return -1;
+        }
+        // 8. If the length of keyB is greater than the length of keyA, return 1.
+        if (keyB.length() > keyA.length()) {
+            return 1;
+        }
+        // 9. Return 0.
+        return 0;
+    }
+
+    /**
+     * PACKAGE_IMPORTS_EXPORTS_RESOLVE(matchKey, matchObj, packageURL, isImports, conditions)
+     */
+    private URI packageImportsExportsResolve(String matchKey, JSDynamicObject matchObj, URI packageURL, boolean isImports, List<String> conditions, TruffleLanguage.Env env) {
+        // 1. If matchKey ends in "/", then
+        if (matchKey.endsWith("/")) {
+            // 1.1 Throw an Invalid Module Specifier error.
+            throw fail(INVALID_MODULE_SPECIFIER, matchKey);
+        }
+        // 2.If matchKey is a key of matchObj and does not contain "*", then
+        if (!matchKey.contains("*") && matchObj.hasOwnProperty(constant(matchKey))) {
+            // 2.1 Let target be the value of matchObj[matchKey].
+            var target = JSObject.get(matchObj, constant(matchKey));
+            // 2.2 Return the result of PACKAGE_TARGET_RESOLVE(packageURL, target, null, isImports,
+            // conditions).
+            return packageTargetResolve(packageURL, target, null, isImports, conditions, env);
+        }
+        var expansionKeys = JSObject.enumerableOwnNames(matchObj).stream().map(key -> key.toString())
+                        // 3. Let expansionKeys be the list of keys of matchObj containing only a
+                        // single "*"
+                        .filter(key -> containsOnlyOne(key, PACKAGE_EXPORT_WILDCARD))
+                        // 3. sorted by the sorting function PATTERN_KEY_COMPARE which orders in
+                        // descending order of specificity
+                        .sorted((keyA, keyB) -> patternKeyCompare(keyA, keyB, packageURL)).toList();
+        for (var expansionKey : expansionKeys) {
+            // 4. For each key expansionKey in expansionKeys, do
+            // 4.1 Let patternBase be the substring of expansionKey up to but excluding the first
+            // "*" character.
+            var patternBase = expansionKey.substring(0, expansionKey.indexOf(PACKAGE_EXPORT_WILDCARD));
+            // 4.2 If matchKey starts with but is not equal to patternBase, then
+            if (!matchKey.equals(patternBase) && matchKey.startsWith(patternBase)) {
+                // 4.2.1 Let patternTrailer be the substring of expansionKey from the index after
+                // the first "*" character.
+                var patternTrailer = expansionKey.substring(expansionKey.indexOf(PACKAGE_EXPORT_WILDCARD) + 1);
+                // 4.2.2 If patternTrailer has zero length, or if matchKey ends with patternTrailer
+                // and the length of matchKey is greater than or equal to the length of
+                // expansionKey, then
+                if (patternTrailer.isEmpty() || (matchKey.endsWith(patternTrailer) && matchKey.length() >= expansionKey.length())) {
+                    // 4.2.2.1 Let target be the value of matchObj[expansionKey].
+                    var target = JSObject.get(matchObj, constant(expansionKey));
+                    // 4.2.2.2 Let patternMatch be the substring of matchKey
+                    // starting at the index of the length of patternBase up to
+                    // the length of matchKey minus the length of patternTrailer.
+                    var patternMatch = matchKey.substring(patternBase.length(), matchKey.length() - patternTrailer.length());
+                    // 4.2.2.3 Return the result of
+                    // PACKAGE_TARGET_RESOLVE(packageURL, target, patternMatch, isImports,
+                    // conditions).
+                    return packageTargetResolve(packageURL, target, patternMatch, isImports, conditions, env);
+                }
+            }
+        }
+        // 5. Return null.
+        return null;
+    }
+
+    /**
+     * PACKAGE_TARGET_RESOLVE(packageURL, target, patternMatch, isImports, conditions)
+     */
+    private URI packageTargetResolve(URI packageURL, Object target, String patternMatch, boolean isImports, List<String> conditions, TruffleLanguage.Env env) {
+        // 1. If target is a String, then
+        if (target instanceof TruffleString targetTStr) {
+            String targetStr = targetTStr.toString();
+            // 1.1 If target does not start with "./", then
+            if (!targetStr.startsWith("./")) {
+                boolean isValidUrl = (asURI(targetStr) != null);
+                // 1.1.1 If isImports is false, or if target starts with "../" or "/", or if target
+                // is a valid URL, then
+                if (!isImports || targetStr.startsWith("../") || targetStr.startsWith("/") || isValidUrl) {
+                    throw fail(INVALID_PACKAGE_TARGET, targetStr);
+                }
+                // 1.1.2 If patternMatch is a String, then
+                if (patternMatch != null) {
+                    // 1.1.2.1 Return PACKAGE_RESOLVE(target with every instance of "*" replaced by
+                    // patternMatch, packageURL + "/").
+                    return packageResolve(targetStr.replaceAll(Pattern.quote(String.valueOf(PACKAGE_EXPORT_WILDCARD)), patternMatch),
+                                    packageURL, env);
+                } else {
+                    // 1.1.3 Return PACKAGE_RESOLVE(target, packageURL + "/").
+                    return packageResolve(targetStr, packageURL, env);
+                }
+            } else {
+                // 1.2 If target split on "/" or "\" contains any "", ".", "..", or "node_modules"
+                // segments after the first "." segment, case insensitive and including percent
+                // encoded variants,
+                for (String seg : targetStr.substring(2).split("[/|\\\\]")) {
+                    if (seg.isEmpty() || seg.equals(DOT) || seg.equals(DOT + DOT) || seg.equalsIgnoreCase(NODE_MODULES)) {
+                        // throw an Invalid Package Target error.
+                        throw fail(INVALID_PACKAGE_TARGET, targetStr);
+                    }
+                }
+                // 1.3 Let resolvedTarget be the URL resolution of the concatenation of packageURL
+                // and target.
+                var resolvedTarget = resolveRelativeToParent(targetStr, packageURL);
+                // 1.4 Assert: packageURL is contained in resolvedTarget.
+                if (!resolvedTarget.normalize().getPath().startsWith(packageURL.normalize().getPath())) {
+                    throw fail(INVALID_PACKAGE_TARGET, targetStr);
+                }
+                // 1.5 If patternMatch is null, then
+                if (patternMatch == null) {
+                    // 1.5.1 Return resolvedTarget.
+                    return resolvedTarget;
+                }
+                // 1.6 If patternMatch split on "/" or "\" contains any "", ".", "..", or
+                // "node_modules" segments, case insensitive and including percent encoded variants.
+                for (String seg : patternMatch.split("[/|\\\\]")) {
+                    if (seg.isEmpty() || seg.equals(DOT) || seg.equals(DOT + DOT) || seg.equalsIgnoreCase(NODE_MODULES)) {
+                        // throw an Invalid Module Specifier error.
+                        throw fail(INVALID_MODULE_SPECIFIER, patternMatch);
+                    }
+                }
+                // 1.7 Return the URL resolution of resolvedTarget with every instance of "*"
+                // replaced with patternMatch.
+                return asURI(resolvedTarget.toString().replaceAll(Pattern.quote(String.valueOf(PACKAGE_EXPORT_WILDCARD)), patternMatch));
+            }
+        } else if (target instanceof JSDynamicObject targetObj && !JSObject.hasArray(targetObj)) {
+            // 2 Otherwise, if target is a non-null Object, then
+
+            // 2.1 If target contains any index property keys, as defined in ECMA-262 6.1.7 Array
+            // Index, throw an Invalid Package Configuration error.
+            for (var key : targetObj.ownPropertyKeys()) {
+                if (JSRuntime.isArrayIndex(key)) {
+                    throw fail(INVALID_PACKAGE_CONFIGURATION, targetObj.toString());
+                }
+            }
+
+            // 2.2 For each property p of target, in object insertion order as
+            for (var keyTStr : JSObject.enumerableOwnNames(targetObj)) {
+                var p = keyTStr.toString();
+                // 2.2.1 If p equals "default" or conditions contains an entry for p, then
+                if (p.equals("default") || conditions.contains(p)) {
+                    // 2.2.1 Let targetValue be the value of the p property in target.
+                    var targetValue = JSObject.get(targetObj, keyTStr);
+                    // 2.2.2 Let resolved be the result of
+                    // PACKAGE_TARGET_RESOLVE(packageURL, targetValue, patternMatch, isImports,
+                    // conditions).
+                    var resolved = packageTargetResolve(packageURL, targetValue, patternMatch, isImports, conditions, env);
+                    // 2.2.3 If resolved is equal to undefined, continue the loop
+                    if (resolved != null) {
+                        // 2.2.4 Return resolved
+                        return resolved;
+                    }
+                }
+            }
+            // 2.3 Return undefined.
+            return null;
+        } else if (target instanceof JSDynamicObject targetObj && JSObject.hasArray(targetObj)) {
+            // 3. Otherwise, if target is an Array, then
+            ScriptArray _target = JSObject.getArray(targetObj);
+            // 3.1 If _target.length is zero, return null.
+            if (_target.length(targetObj) == 0) {
+                return null;
+            }
+            // 3.2 For each item targetValue in target, do
+            for (int i = 0; i < _target.length(targetObj); i++) {
+                var targetValue = _target.getElement(targetObj, i);
+                // 3.2.1 Let resolved be the result of PACKAGE_TARGET_RESOLVE( packageURL,
+                // targetValue, patternMatch, isImports, conditions), continuing the loop on any
+                // Invalid Package Target error.
+                var resolved = packageTargetResolve(packageURL, targetValue, patternMatch, isImports, conditions, env);
+                // 3.2.2 If resolved is undefined, continue the loop.
+                // 3.2.3 Return resolved.
+                if (resolved != null) {
+                    return resolved;
+                }
+            }
+        }
+        // 4. Otherwise, if target is null, return null.
+        if (target == null) {
+            return null;
+        }
+        // 5. Otherwise throw an Invalid Package Target error.
+        throw fail(INVALID_PACKAGE_TARGET, target.toString());
     }
 
     /**
@@ -447,45 +752,42 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
         // position at the length of packageName.
         String packageSpecifierSub = packageSpecifier.substring(packageName.length());
         String packageSubpath = DOT + packageSpecifierSub;
-        // 8. If packageSubpath ends in "/", then
+
         if (packageSubpath.endsWith(SLASH)) {
             // Throw an Invalid Module Specifier error.
             throw fail(INVALID_MODULE_SPECIFIER, packageSpecifier);
         }
-        // 9. Let selfUrl be the result of PACKAGE_SELF_RESOLVE(packageName, packageSubpath,
+
+        // 8. Let selfUrl be the result of PACKAGE_SELF_RESOLVE(packageName, packageSubpath,
         // parentURL).
-        URI selfUrl = packageSelfResolve(packageName, parentURL, env);
-        // 10. If selfUrl is not undefined, return selfUrl.
+        URI selfUrl = packageSelfResolve(packageName, packageSubpath, parentURL, env);
+        // 9. If selfUrl is not undefined, return selfUrl.
         if (selfUrl != null) {
             return selfUrl;
         }
         TruffleFile currentParentUrl = env.getPublicTruffleFile(parentURL);
-        // 11. While parentURL is not the file system root,
+        // 10. While parentURL is not the file system root,
         while (currentParentUrl != null && !isRoot(currentParentUrl)) {
-            // 11.1 Let packageURL be the URL resolution of "node_modules/" concatenated with
+            // 10.1 Let packageURL be the URL resolution of "node_modules/" concatenated with
             // packageSpecifier, relative to parentURL.
             URI packageUrl = getPackageUrl(packageName, currentParentUrl);
-            // 11.2 Set parentURL to the parent folder URL of parentURL.
+            // 10.2 Set parentURL to the parent folder URL of parentURL.
             currentParentUrl = currentParentUrl.getParent();
-            // 11.3 If the folder at packageURL does not exist, then
+            // 10.3 If the folder at packageURL does not exist, then
             TruffleFile maybeFolder = packageUrl != null ? env.getPublicTruffleFile(packageUrl) : null;
             if (maybeFolder == null || !maybeFolder.exists() || !maybeFolder.isDirectory()) {
                 continue;
             }
-            // 11.4 Let pjson be the result of READ_PACKAGE_JSON(packageURL).
+            // 10.4 Let pjson be the result of READ_PACKAGE_JSON(packageURL).
             PackageJson pjson = readPackageJson(packageUrl, env);
-            // 11.5 If pjson is not null and pjson.exports is not null or undefined, then
+            // 10.5 If pjson is not null and pjson.exports is not null or undefined, then
             if (pjson != null && pjson.hasExportsProperty()) {
-                var exp = pjson.getExport(packageSubpath);
-                if (exp != null) {
-                    // we should receive a map of the form `type => path` for the requested export. determine the best
-                    // import type to use and resolve from there.
-                    return exportForImport(packageUrl, exp, env);
-                }
-                throw fail(UNSUPPORTED_PACKAGE_EXPORTS, packageSpecifier);
+                // 10.5.1 Return the result of PACKAGE_EXPORTS_RESOLVE(packageURL, packageSubpath,
+                // pjson.exports, defaultConditions).
+                return packageExportsResolve(packageUrl, packageSubpath, pjson.getExportsProperty(), getConditions(), env);
             } else if (packageSubpath.equals(DOT)) {
-                // 11.6 Otherwise, if packageSubpath is equal to ".", then
-                // 11.6.1 If pjson.main is a string, then return the URL resolution of main in
+                // 10.6 Otherwise, if packageSubpath is equal to ".", then
+                // 10.6.1 If pjson.main is a string, then return the URL resolution of main in
                 // packageURL.
                 if (pjson != null && pjson.hasMainProperty()) {
                     TruffleString main = pjson.getMainProperty();
@@ -496,10 +798,10 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
                     return TryCommonJS;
                 }
             }
-            // 7. Otherwise, Return the URL resolution of packageSubpath in packageURL.
+            // 10.7. Otherwise, Return the URL resolution of packageSubpath in packageURL.
             return packageUrl.resolve(packageSubpath);
         }
-        // 12. Will Throw a Module Not Found error.
+        // 11. Will Throw a Module Not Found error.
         return TryCustomESM;
     }
 
@@ -513,7 +815,7 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
     /**
      * PACKAGE_SELF_RESOLVE(packageName, packageSubpath, parentURL).
      */
-    private URI packageSelfResolve(String packageName, URI parentURL, TruffleLanguage.Env env) {
+    private URI packageSelfResolve(String packageName, String packageSubpath, URI parentURL, TruffleLanguage.Env env) {
         // 1. Let packageURL be the result of LOOKUP_PACKAGE_SCOPE(parentURL).
         URI packageUrl = lookupPackageScope(parentURL, env);
         // 2. If packageURL is null, then Return undefined.
@@ -528,7 +830,9 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
         }
         // 5. If pjson.name is equal to packageName, then
         if (pjson.namePropertyEquals(packageName)) {
-            throw failMessage(UNSUPPORTED_PACKAGE_EXPORTS);
+            // 5.1. Return the result of PACKAGE_EXPORTS_RESOLVE(packageURL, packageSubpath,
+            // pjson.exports, defaultConditions).
+            return packageExportsResolve(packageUrl, packageSubpath, pjson.getExportsProperty(), getConditions(), env);
         }
         // 6. Otherwise, return undefined.
         return null;
@@ -580,14 +884,26 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
             this.jsonObj = jsonObj;
         }
 
-        boolean hasTypeModule() {
+        boolean hasTypeProperty() {
             if (hasNonNullProperty(jsonObj, TYPE)) {
                 Object nameValue = JSObject.get(jsonObj, TYPE);
                 if (nameValue instanceof TruffleString nameStr) {
-                    return Strings.equals(MODULE, nameStr);
+                    String type = nameStr.toString();
+                    if (type.equals(TYPE_MODULE) || type.equals(TYPE_COMMONS_JS)) {
+                        return true;
+                    }
                 }
             }
             return false;
+        }
+
+        String getTypeProperty() {
+            assert hasTypeProperty();
+            Object nameValue = JSObject.get(jsonObj, TYPE);
+            if (nameValue instanceof TruffleString nameStr) {
+                return nameStr.toString();
+            }
+            return null;
         }
 
         private static boolean hasNonNullProperty(JSDynamicObject object, TruffleString keyName) {
@@ -602,52 +918,18 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
             return hasNonNullProperty(jsonObj, EXPORTS_PROPERTY_NAME);
         }
 
-        public Map<String, String> getExport(String specifier) {
-            assert hasNonNullProperty(jsonObj, EXPORTS_PROPERTY_NAME);
-            var data = JSObject.get(jsonObj, EXPORTS_PROPERTY_NAME);
-            if (data instanceof JSDynamicObject exportsObj) {
-                for (TruffleString key : JSObject.enumerableOwnNames(exportsObj)) {
-                    // find a match for the requested export...
-                    if (key.toString().equals(specifier)) {
-                        // if we found it, it should be a nested object with export mappings. at this point, we've
-                        // already matched the path, so these are mappings of (type => path). `path` must be relative to
-                        // the package root, must start with `.`, must not contain relative backwards references, and
-                        // must be an extant regular file.
-                        Object value = JSObject.get(exportsObj, key);
-                        if (value instanceof JSDynamicObject valueObj) {
-                            var exportKeys = valueObj.ownPropertyKeys();
-                            var exportMap = new HashMap<String, String>();
-                            for (Object exportKey : exportKeys) {
-                                if (exportKey instanceof TruffleString exportKeyStr) {
-                                    Object exportValue = JSObject.get(valueObj, exportKeyStr);
-                                    if (Strings.isTString(exportValue)) {
-                                        var exportStr = exportKeyStr.toString();
-                                        var exportVal = exportValue.toString();
-                                        if (!exportVal.startsWith(".") || exportVal.contains("..")) {
-                                            // must start with `.`, must not contain `..`
-                                            throw failMessage(INVALID_PACKAGE_EXPORT + exportStr);
-                                        }
-                                        exportMap.put(exportKeyStr.toString(), exportValue.toString());
-                                    }
-                                } else {
-                                    throw failMessage(UNSUPPORTED_PACKAGE_EXPORTS + exportKey.toString());
-                                }
-                            }
-                            return exportMap;
-                        } else if (value instanceof TruffleString exportStr) {
-                            // if the export is a string, it should be a path to the file to import.
-                            if (!exportStr.toString().startsWith(".") || exportStr.toString().contains("..")) {
-                                // must start with `.`, must not contain `..`
-                                throw failMessage(INVALID_PACKAGE_EXPORT + exportStr);
-                            }
-                            return Map.of(EXPORT_TYPE_DEFAULT, exportStr.toString());
-                        } else {
-                            throw failMessage(INVALID_PACKAGE_EXPORT + value);
-                        }
-                    }
-                }
-            }
-            return null;
+        public Object getExportsProperty() {
+            assert hasExportsProperty();
+            return JSObject.get(jsonObj, EXPORTS_PROPERTY_NAME);
+        }
+
+        public boolean hasImportsProperty() {
+            return hasNonNullProperty(jsonObj, IMPORTS_PROPERTY_NAME) && (JSObject.get(jsonObj, IMPORTS_PROPERTY_NAME) instanceof JSDynamicObject);
+        }
+
+        public JSDynamicObject getImportsProperty() {
+            assert hasImportsProperty();
+            return (JSDynamicObject) JSObject.get(jsonObj, IMPORTS_PROPERTY_NAME);
         }
 
         public boolean hasMainProperty() {

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
@@ -322,6 +322,26 @@ public final class JSContextOptions {
     @Option(name = COMMONJS_REQUIRE_CWD_NAME, category = OptionCategory.USER, usageSyntax = "<path>", help = "CommonJS default current working directory.") //
     public static final OptionKey<String> COMMONJS_REQUIRE_CWD = new OptionKey<>("");
 
+    public static final String COMMONJS_REQUIRE_USER_CONDITIONS_NAME = JS_OPTION_PREFIX + "commonjs-require-user-conditions";
+    @Option(name = COMMONJS_REQUIRE_USER_CONDITIONS_NAME, category = OptionCategory.USER, usageSyntax = "<condition1>,<condition2>,...", help = "Custom user conditions when resolving package exports and imports, in addition to graaljs, import, require, default") public static final OptionKey<List<String>> COMMONJS_REQUIRE_USER_CONDITIONS = new OptionKey<>(
+                    Collections.emptyList(),
+                    new OptionType<>("commonjs-require-condition", new Function<String, List<String>>() {
+                        @Override
+                        public List<String> apply(String value) {
+                            if (value.isEmpty()) {
+                                return Collections.emptyList();
+                            }
+                            List<String> conditions = new ArrayList<>();
+                            for (String condition : value.split(",")) {
+                                if (condition.isEmpty() || condition.startsWith(".") || condition.contains(",") || condition.matches("\\d+")) {
+                                    throw new IllegalArgumentException("Unexpected condition: " + condition);
+                                }
+                                conditions.add(condition);
+                            }
+                            return conditions;
+                        }
+                    }));
+
     public static final String COMMONJS_CORE_MODULES_REPLACEMENTS_NAME = JS_OPTION_PREFIX + "commonjs-core-modules-replacements";
     @Option(name = COMMONJS_CORE_MODULES_REPLACEMENTS_NAME, category = OptionCategory.USER, usageSyntax = "<name>:<module>,...", help = "Npm packages used to replace global Node.js builtins.") //
     public static final OptionKey<Map<String, String>> COMMONJS_CORE_MODULES_REPLACEMENTS = new OptionKey<>(Collections.emptyMap(),
@@ -1066,6 +1086,11 @@ public final class JSContextOptions {
     public String getRequireCwd() {
         CompilerAsserts.neverPartOfCompilation("Context patchable option load was assumed not to be accessed in compiled code.");
         return COMMONJS_REQUIRE_CWD.getValue(optionValues);
+    }
+
+    public List<String> getUserConditions() {
+        CompilerAsserts.neverPartOfCompilation("Context patchable option load was assumed not to be accessed in compiled code.");
+        return COMMONJS_REQUIRE_USER_CONDITIONS.getValue(optionValues);
     }
 
     public boolean isCrypto() {

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/Strings.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/Strings.java
@@ -364,6 +364,7 @@ public final class Strings {
     public static final TruffleString DIRNAME_VAR_NAME = constant("__dirname");
     public static final TruffleString MODULE_PROPERTY_NAME = MODULE;
     public static final TruffleString EXPORTS_PROPERTY_NAME = constant("exports");
+    public static final TruffleString IMPORTS_PROPERTY_NAME = constant("imports");
     public static final TruffleString REQUIRE_PROPERTY_NAME = constant("require");
     public static final TruffleString RESOLVE_PROPERTY_NAME = RESOLVE;
     public static final TruffleString LOADED_PROPERTY_NAME = constant("loaded");


### PR DESCRIPTION
Best effort Module Resolution Algorithm implementation based on Node.js 25.2.1 as documented in <https://nodejs.org/api/esm.html#resolution-and-loading-algorithm>.

The following features are not implemented:

- **DETECT_MODULE_SYNTAX**(source)  is not implemented
- In **ESM_FILE_FORMAT**, node.js will try to guess the format of a file with no extension. I kept the original behavoir of **esmFileFormat** which is throwing an error (Otherwise it will break some tests on some other places where I dont want to touch...)
- ".wasm" files are not handled by **ESM_FILE_FORMAT**

This patch breaks one unit test:

```java
@Test
public void dontImportCommonJs() throws IOException {
	final String src = "import('with-package').then(x => {throw 'unexpected'}).catch(console.log);";
	final String out = "TypeError: Unsupported file extension: '" + getTestRootFolderUrl() + "node_modules/with-package/alternative-index.js'\n";
	runAndExpectOutput(src, out);
}
```

The previous behavoir with regard to using `import` with CommonJS modules was:

- `import()` can't import a commonjs module with `.js` extension, in a package not marked with `"type"="module"`
- `import()` can import a commonjs module with `.cjs` extension.
- `import()` can import a commonjs module with `.js` extension but not in a package

As *import/import() can be used to load JavaScript CommonJS modules* stated in [packages.html](https://nodejs.org/api/packages.html).
I believe it is fair to expect `import/import()` to be able to import CommonJS modules. 
In this patch, `import` can import a commonjs module with a `cjs` extension, or with a `js` extension and in a package not marked with `"type"="module"`.

I couldn't get _WebAssemblySimpleTestSuite_ working correctly (error: WebAssembly API enabled but "wasm" language cannot be accessed! Make sure the "wasm" l
anguage is found on the module path and one of the permitted languages when creating the Context). All other tests are running correctly.

Another thing to note:

In this patch, if `esmResolve` returns a result and `esmFileFormat` returns `CommonJs`, it will pass the resoluted path directly to `tryLoadingAsCommonjsModule`. Instead of the original `specifier`. 
I don't know if this is the best way to do it, but at least we can import a CommonJs module exported in `exports` using `import` now (ideally we should make `require` also support it).

This patch is based on #904