### PR TITLE
test(object_template): install named enumerator handler in CreateWithEmptyNamedEnumerator

### DIFF
--- a/graal-nodejs/test/graal/unit/object_template.cc
+++ b/graal-nodejs/test/graal/unit/object_template.cc
@@ -145,6 +145,7 @@ EXPORT_TO_JS(CreateWithEmptyNamedEnumerator) {
             nullptr, // deleter
             EmptyPropertyEnumeratorCallback // enumerator
     );
+    objectTemplate->SetHandler(handler);
 
     Local<Context> context = isolate->GetCurrentContext();
     Local<Object> instance = objectTemplate->NewInstance(context).ToLocalChecked();

--- a/graal-nodejs/test/graal/unit/object_template.js
+++ b/graal-nodejs/test/graal/unit/object_template.js
@@ -73,10 +73,12 @@ describe('ObjectTemplate', function () {
         it('should not crash with an empty named enumerator', function () {
             var obj = module.ObjectTemplate_CreateWithEmptyNamedEnumerator();
             assert.strictEqual(Object.keys(obj).length, 0);
+            assert.deepStrictEqual(Reflect.ownKeys(obj), []);
         });
         it('should not crash with an empty indexed enumerator', function () {
             var obj = module.ObjectTemplate_CreateWithEmptyIndexedEnumerator();
             assert.strictEqual(Object.keys(obj).length, 0);
+            assert.deepStrictEqual(Reflect.ownKeys(obj), []);
         });
     });
 });


### PR DESCRIPTION
## Problem

`CreateWithEmptyNamedEnumerator` in `object_template.cc` constructed a
`NamedPropertyHandlerConfiguration` with an enumerator callback but never
called `objectTemplate->SetHandler(handler)`. The handler was silently
discarded, so the object template had **no named interceptor installed**.

The JS test then checked `Object.keys(obj).length === 0`, which passes
trivially for any plain object — the enumerator callback was never
invoked. The test was not covering the named enumerator code path at all,
despite its name.

The parallel `CreateWithEmptyIndexedEnumerator` function correctly called
`SetHandler` all along.

## Fix

- Add the missing `objectTemplate->SetHandler(handler)` call so the named
  interceptor is actually installed.
- Strengthen both enumerator tests to also assert
  `Reflect.ownKeys(obj)` is `[]`, which routes through the interceptor and
  confirms it returns empty.

## Test

Syntax check passes:
```
node --check graal-nodejs/test/graal/unit/object_template.js
```

Full mx test run requires GraalVM build tooling (`mx`) not available in
this environment.